### PR TITLE
Revert "Bump version from 0.1.0 to 0.1.1"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,3 @@
-# 0.1.1
-
 # 0.1.0
 
 * Initial version moved from helly25_mbo//testing/bashtest*

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,7 +18,7 @@
 # Due to flag and test references to the repo name we use the old name for now.
 module(
     name = "helly25_bashtest",
-    version = "0.1.1",
+    version = "0.1.0",
     repo_name = "com_helly25_bashtest",
 )
 


### PR DESCRIPTION
Reverts helly25/bashtest#2

Broken release 0.1.0 process.