### PR TITLE
Added convenient target to print bashtest help 

### DIFF
--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -104,6 +104,7 @@ http_archive(
   name = "${WORKSPACE_NAME}",
   url = "https://github.com/helly25/${PACKAGE_NAME}/releases/download/${TAG}/${ARCHIVE}",
   sha256 = "${SHA256}",
+  strip_prefix = "${PREFIX}",
 )
 \`\`\`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 0.1.1
 
+* Added convenient target to print `bashtest` help `bazel run //bashtest:bashtest_help` which can be used with `|pandoc -s -t man|man -l -`.
+
 # 0.1.0
 
 * Initial version moved from helly25_mbo//testing/bashtest*

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ The library is tested with continuous integration: [![Test](https://github.com/h
 
 ## Bashtest
 
-Run the following command to get detailed information on the actual bashtest.sh script:
+Run one of the following commands to get detailed information on the actual bashtest.sh script:
 
-```sh
-(. testing/bashtest.sh --help)`
-```
+* `bazel run //bashtest:bashtest_help`
+* `bazel run //bashtest:bashtest_help | pandoc -s -t man | man -l -`
+* `bazel run //bashtest:bashtest_help | pandoc | lynx -stdin`
 
 The flags can be used on the `bazel run` and `bazel test` commands (the latter requiring `--test_arg=...`).
 

--- a/bashtest/BUILD.bazel
+++ b/bashtest/BUILD.bazel
@@ -33,3 +33,27 @@ alias(
     actual = ":bashtest_sh",
     visibility = ["//visibility:public"],
 )
+
+genrule(
+    name = "bashtest_help",
+    testonly = 1,
+    srcs = ["bashtest.sh"],
+    outs = ["bashtest_help.sh"],
+    cmd = """
+    echo "#!/usr/bin/env bash" >$@
+    echo "bash $< --help || true" >>$@
+    """,
+    executable = 1,
+    tags = ["manual"],
+    visibility = ["//visibility:private"],
+)
+
+genrule(
+    name = "bashtest_help_md",
+    testonly = 1,
+    srcs = ["bashtest.sh"],
+    outs = ["bashtest_help.md"],
+    cmd = """bash $< --help >$@ || true""",
+    tags = ["manual"],
+    visibility = ["//visibility:private"],
+)

--- a/bashtest/README.md
+++ b/bashtest/README.md
@@ -4,7 +4,7 @@ Bashtest provides `sh_test` wrapper that simplifies the creation of shell tests.
 
 
   * bashtest:bashtest, bashtest/bashtest.sh
-  * sh_library `bashtest.sh` which provides a test runner for complex shell tests involving golden files that provides built-in golden update functionality (see `(. bashtest/bashtest.sh --help)`).
+  * sh_library `bashtest.sh` which provides a test runner for complex shell tests involving golden files that provides built-in golden update functionality (see `bazel run //bashtest:bashtest_help`).
     * status helper `test_has_erro`: Returns whether a test function has had an error.
     * status helper `test_has_failed_tests`: Returns whether a test program had previous failing test functions.
     * expectation `expect_eq` "\${LHS}" "\${RHS}": Asserts that two strings are the same.

--- a/bashtest/bashtest.sh
+++ b/bashtest/bashtest.sh
@@ -1,5 +1,4 @@
-#!/usr/bin/env bash
-
+# shellcheck disable=SC2148 # This is not executable
 # SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -15,62 +14,68 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# BashTest: see `bashtest.sh -h`
+# BashTest: see `bazel run //bashtest:bashtest_help`
 
 set -euo pipefail
 
 function die() { echo >&2 "ERROR: ${*}"; exit 1; }
 
 _BASHTEST_USAGE=$(cat <<'EOF'
-bashtest.sh - A Bazel shell test runner.
+# bashtest.sh - A Bazel shell test runner.
 
-- All declared functions that start with "test::" are considered as tests.
-- Each test should `return 0` to indicate success or `return 1` for failure.
-- Call `test_runner` at the end of the test program.
-- Provides '${BASHTEST_TMPDIR}' which is a test scratch directory.
-- Tests can be filtered (skipping non matching) using flag '--test_filter <pattern>'.
-- Tests that use diff functionality 'expect_files_eq' can use '-u="${PWD}"' to
+* All declared functions that start with "test::" are considered as tests.
+* Each test should use `return 0` to indicate success or `return 1` for failure.
+* Call `test_runner` at the end of the test program.
+* Provides '${BASHTEST_TMPDIR}' which is a test scratch directory.
+* Tests can be filtered (skipping non matching) using flag '--test_filter `<pattern>`'.
+* Tests that use diff functionality 'expect_files_eq' can use '-u="${PWD}"' to
   update their golden files.
 
-Usage:
-  bazel test <test_target> [ --test_arg=-f=<pattern> ] [ -v ] [ -u="${PWD}" ]
-  bazel run <test_target -- [ -f=<pattern> ] [ -v ][ -u="${PWD}" ]
+## Usage:
 
--f --test-filter <pattern>  A glob pattern for tests to run (skip others). The
-                            test is considered failing of no test was run.
--u --update <workspace>     Update golden files, assuming the <workspace>.
--v --verbose                Show additional output while tests succeed or fail.
-                            Prints all test calls and file diffs.
+* bazel test `<test_target>` [ --test_arg=-f=`<pattern>` ] [ -v ] [ -u="${PWD}" ]
+* bazel run `<test_target>` -- [ -f=`<pattern>` ] [ -v ][ -u="${PWD}" ]
 
-Assertions:
-  expect_eq "${LHS}" "${RHS}"
+## Flags:
+
+* -f --test-filter `<pattern>`  A glob pattern for tests to run (skip others). The
+                                test is considered failing of no test was run.
+* -u --update `<workspace>`     Update golden files, assuming the `<workspace>`.
+* -v --verbose                  Show additional output while tests succeed or fail.
+                                Prints all test calls and file diffs.
+
+## Assertions:
+
+* expect_eq "${LHS}" "${RHS}"
                             Asserts that two strings are the same.
 
-  expect_ne "${LHS}" "${RHS}"
+* expect_ne "${LHS}" "${RHS}"
                             Asserts that two strings are different.
 
-  expect_files_eq "${LHS}" "${RHS}"
+* expect_files_eq "${LHS}" "${RHS}"
                             Asserts that two file are the same (supports golden
                             updates).
 
-  expect_contains "${EXPECTED}" "${ARRAY[@]}"
+* expect_contains "${EXPECTED}" "${ARRAY[@]}"
                             Assert that one string is present in an array.
 
-  expect_not_contains "${EXPECTED}" "${ARRAY[@]}"
+* expect_not_contains "${EXPECTED}" "${ARRAY[@]}"
                             Assert that one string is NOT present in an array.
 
 
-Status:
-  test_has_error            Returns whether a test function has had an error.
-  test_has_failed_tests     Returns whether a test program had previous
+## Status:
+
+* test_has_error            Returns whether a test function has had an error.
+* test_has_failed_tests     Returns whether a test program had previous
                             failing test functions.
 
-Setup/Shutdown:
-  test::test_init           If present, then this function runs first!
-                            Test will only be executed if it succeeds.
-  test::test_done           If present, then this function runs last!
+## Setup/Shutdown:
 
-Example:
+* test::test_init           If present, then this function runs first!
+                            Test will only be executed if it succeeds.
+* test::test_done           If present, then this function runs last!
+
+## Example:
 
 ```sh
 # shellcheck disable=SC2317 # Functions are called bashtest
@@ -125,7 +130,7 @@ while getopts -- '-:f:hu:v' OPTION; do
     fi
     case "${OPTION}" in
         f|test[-_]filter) _BASHTEST_FILTER="${OPTARG}" ;;
-        h|help) echo "${_BASHTEST_USAGE}"; return 2 ;;
+        h|help) echo "${_BASHTEST_USAGE}"; exit 2 ;;
         u|update[-_]golden) _BASHTEST_UPDATE_GOLDEN="${OPTARG}" ;;
         v|verbose) _BASHTEST_VERBOSE=1 ;;
         *) die "Unknown flag '${OPTERR}'." ;;

--- a/tools/trigger_release.sh
+++ b/tools/trigger_release.sh
@@ -54,8 +54,9 @@ fi
 
 grep "${VERSION}" < <(git tag -l) && die "Version tag is already in use."
 
-# Should the tag have the changelog parts?
-git tag -s -a "${VERSION}" -m "New release tag version: '${VERSION}'."
+git tag -s -a "${VERSION}" \
+    -m "New release tag version: '${VERSION}'." \
+    -m "$(awk '/^#/{if(NR>1)exit}/^[^#]/{print}' <CHANGELOG.md)"
 git push origin --tags
 
 echo "Next version: ${NEXT_VERSION}"
@@ -97,7 +98,7 @@ if which gh; then
         else
             gh pr merge "${NEXT_BRANCH}" --auto -d -s -b "${MERGE_BODY}" -t "${MERGE_SUBJECT}"
             git checkout main
-            git branch -d "${NEXT_BRANCH}"
+            git branch -d "${NEXT_BRANCH}" || true
             echo "PR ${PRNUM} cannot be merged via admin override."
             echo "Please approve it at ${PRURL}."
         fi


### PR DESCRIPTION
* Make release script automatically add the `strip_prefix` attribute for workspace installs.