### PR TITLE
chore: bump to 0.3.1 and auto-publish releases to the BCR

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,37 @@
+# Publish a new release to the Bazel Central Registry (BCR).
+#
+# Called by release.yml after a release is cut. Can also be run manually from
+# the Actions UI ("Run workflow") against a release tag to retry a failed run.
+name: Publish to BCR
+
+on:
+  workflow_call:
+    inputs:
+      tag_name:
+        required: true
+        type: string
+    secrets:
+      BCR_PUBLISH_TOKEN:
+        required: true
+  workflow_dispatch: {}
+
+permissions: read-all
+
+jobs:
+  publish:
+    permissions:
+      contents: write
+    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v1.4.1
+    with:
+      tag_name: ${{ inputs.tag_name || github.ref_name }}
+      registry_fork: helly25/bazel-central-registry
+      # Personal-account PAT: open a draft PR so the author can click "Ready for
+      # review" to approve it (GitHub forbids reviewing your own PR).
+      draft: true
+      # Our release flow emits no SLSA attestations and uploads no workflow
+      # artifact, so compute integrity by downloading the tarball from the URL
+      # in .bcr/source.template.json instead.
+      attest: false
+      download_default_release_artifacts: false
+    secrets:
+      publish_token: ${{ secrets.BCR_PUBLISH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,3 +12,15 @@ jobs:
     with:
       release_files: bashtest-*.tar.gz
       prerelease: true
+
+  # Mirror the release to the Bazel Central Registry (replaces the retired
+  # publish-to-bcr GitHub App). See .github/workflows/publish.yaml.
+  publish:
+    needs: release
+    permissions:
+      contents: write
+    uses: ./.github/workflows/publish.yaml
+    with:
+      tag_name: ${{ github.ref_name }}
+    secrets:
+      BCR_PUBLISH_TOKEN: ${{ secrets.BCR_PUBLISH_TOKEN }}


### PR DESCRIPTION
Bumps bashtest 0.3.0 → 0.3.1 and automates Bazel Central Registry publishing.

## Changes
- **`MODULE.bazel`**: version `0.3.0` → `0.3.1`.
- **`trigger_release.sh`**: add `tag`/`bump`/`release` subcommands and `--dry-run`.
- **`.github/workflows/publish.yaml`** (new) + **`release.yml`** hook: auto-publish to the BCR on release via [bazel-contrib/publish-to-bcr](https://github.com/bazel-contrib/publish-to-bcr)'s reusable workflow `@v1.4.1` (replaces the retired Publish-to-BCR app). Pushes to `helly25/bazel-central-registry`, opens a **draft** PR to `bazelbuild/bazel-central-registry`, integrity computed from `.bcr/source.template.json`'s URL.

**0.3.1 is the first release published to the BCR through this workflow** — verifying the migration end-to-end before rolling it out to the other helly25 modules.