### PR TITLE
ci: fix BCR publish job startup_failure (drop job-level permissions)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,6 @@ jobs:
   # publish-to-bcr GitHub App). See .github/workflows/publish.yaml.
   publish:
     needs: release
-    permissions:
-      contents: write
     uses: ./.github/workflows/publish.yaml
     with:
       tag_name: ${{ github.ref_name }}


### PR DESCRIPTION
The `0.3.1` release run hit `startup_failure` (no jobs ran). Isolated to the `publish` job in release.yml: the standalone `publish.yaml` dispatch validated and ran (authenticated with the PAT, cloned the BCR fork), so the publish chain is sound. The only structural delta from the proven [rules_lint](https://github.com/aspect-build/rules_lint/blob/main/.github/workflows/release.yml) pattern was a job-level `permissions:` block on the publish job. Removing it to match. Re-cut 0.3.1 after merge.