### PR TITLE
ci: fix BCR publish permission cascade (startup_failure)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,8 +15,6 @@ on:
         required: true
   workflow_dispatch: {}
 
-permissions: read-all
-
 jobs:
   publish:
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,10 @@ jobs:
   # publish-to-bcr GitHub App). See .github/workflows/publish.yaml.
   publish:
     needs: release
+    # Grant what publish.yaml's job requests; a called workflow cannot exceed
+    # the caller's permissions.
+    permissions:
+      contents: write
     uses: ./.github/workflows/publish.yaml
     with:
       tag_name: ${{ github.ref_name }}


### PR DESCRIPTION
Fixes the `0.3.1` release `startup_failure`. Error: *the nested job 'publish' is requesting 'contents: write', but is only allowed 'contents: read'* + the workflow requesting `read-all`.

Root cause: a called reusable workflow can't exceed the caller's permissions.
- **release.yml** publish job: grant `contents: write` (PR #17 wrongly removed it).
- **publish.yaml**: drop top-level `permissions: read-all` — as a reusable workflow it demanded every read scope from the caller. Matches the [rules_lint](https://github.com/aspect-build/rules_lint/blob/main/.github/workflows/publish.yaml) pattern.

Then I'll re-cut 0.3.1.