### PR TITLE
Extend BCR support matrix (Bazel 9.x + more Linux); 0.3.2

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -2,8 +2,12 @@ matrix:
   bazel:
   - 7.x
   - 8.x
+  - 9.x
   platform:
+  - ubuntu2204
   - ubuntu2404
+  - debian12
+  - rockylinux8
   - macos
 tasks:
   verify_targets:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.3.2
+
+* Extended the BCR presubmit support matrix: added Bazel 9.x and the Linux platforms ubuntu 22.04, Debian 12, and Rocky Linux 8 (alongside the existing ubuntu 24.04 and macOS).
+
 # 0.3.1
 
 # 0.3.0

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,7 +18,7 @@
 # Due to flag and test references to the repo name we use the old name for now.
 module(
     name = "helly25_bashtest",
-    version = "0.3.1",
+    version = "0.3.2",
     repo_name = "com_helly25_bashtest",
 )
 


### PR DESCRIPTION
Widens the matrix the BCR presubmit exercises, shipping as **0.3.2**.

- **Bazel:** `7.x, 8.x` → add **`9.x`** (supported since 0.3.0).
- **Platforms:** add **`ubuntu2204`** and other Linux (**`debian12`**, **`rockylinux8`**) alongside the existing `ubuntu2404` + `macos`.

ubuntu **26.04 is not a bazelci/BCR platform yet** (only up to `ubuntu2404` exists), so it's omitted for now. Easy to add once it lands.

Matrix is a full cross-product (3 bazel × 5 platform = 15 build jobs in BCR presubmit). Bump `MODULE.bazel` → 0.3.2 + CHANGELOG. After merge → tag 0.3.2 → the BCR PR runs this expanded matrix.