### PR TITLE
ci(bcr): test on macos_arm64 instead of Intel macos

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -8,7 +8,7 @@ matrix:
   - ubuntu2404
   - debian12
   - rockylinux8
-  - macos
+  - macos_arm64
 tasks:
   verify_targets:
     name: Verify build targets


### PR DESCRIPTION
The BCR `macos` platform runs on Intel x86_64, which we no longer test. This switches the presubmit matrix to `macos_arm64` (Apple Silicon).

- platform: `macos` → `macos_arm64`