### PR TITLE
feat: add text-matching assertions (expect_matches, expect_output_contains, expect_pcre_matches); bump to 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-# 0.4.1
+# 0.5.0
+
+* Added text-matching assertions:
+  * `expect_output_contains` / `expect_output_not_contains`: literal substring checks.
+  * `expect_matches` / `expect_not_matches`: extended regular expression (ERE) checks via bash's built-in `[[ =~ ]]` (no subprocess, so SIGPIPE-safe under `set -o pipefail`). `^`/`$` anchor the whole text, not individual lines.
+  * `expect_pcre_matches` / `expect_pcre_not_matches`: Perl Compatible Regular Expression checks. These shell out to an external tool (`grep -P`, `ggrep -P`, `pcre2grep`, or `pcregrep`) via a here-string and fail with an actionable message when none is available.
+* Documented the `cmd | grep -q` SIGPIPE-under-pipefail pitfall in the README.
 
 # 0.4.0
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -17,7 +17,7 @@
 
 module(
     name = "helly25_bashtest",
-    version = "0.4.1",
+    version = "0.5.0",
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.8.2")

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ The flags can be used on the `bazel run` and `bazel test` commands (the latter r
 * expectation `expect_files_eq` "\${LHS}" "\${RHS}": Asserts that two file are the same (supports golden updates).
 * expectation `expect_contains` "\${EXPECTED}" "\${ARRAY[@]}": Assert that one string is present in an array.
 * expectation `expect_not_contains` "\${EXPECTED}" "\${ARRAY[@]}": Assert that one string is not present in an array.
+* expectation `expect_output_contains` "\${SUBSTRING}" "\${TEXT}": Assert that a text contains a literal substring.
+* expectation `expect_output_not_contains` "\${SUBSTRING}" "\${TEXT}": Assert that a text does not contain a literal substring.
+* expectation `expect_matches` "\${REGEX}" "\${TEXT}": Assert that a text matches an extended regular expression (bash built-in; `^`/`$` anchor the whole text).
+* expectation `expect_not_matches` "\${REGEX}" "\${TEXT}": Assert that a text does not match an extended regular expression.
+* expectation `expect_pcre_matches` "\${REGEX}" "\${TEXT}": Assert that a text matches a Perl Compatible Regular Expression (requires an external PCRE tool: `grep -P`, `pcre2grep`, or `pcregrep`).
+* expectation `expect_pcre_not_matches` "\${REGEX}" "\${TEXT}": Assert that a text does not match a Perl Compatible Regular Expression.
 * special test function `test::test_init`: If present, then this function runs first! Tests will only be executed if it succeeds.
 * special test function `test::test_done`: If present, then this function runs last!
 
@@ -56,6 +62,21 @@ bashtest(
     srcs = ["sh_test.sh"],
 )
 ```
+
+### Matching command output
+
+To assert on captured command output, prefer the built-in matchers
+(`expect_output_contains`, `expect_matches`, `expect_pcre_matches`) over
+hand-rolled pipelines.
+
+> [!WARNING]
+> bashtest runs under `set -o pipefail` (and recommends the same for your test
+> scripts). The common idiom `printf '%s' "${output}" | grep -qE '...'` is a
+> footgun there: `grep -q` exits on the first match, the producing command gets
+> `SIGPIPE`, and `pipefail` turns that into a non-zero exit — a flaky failure on
+> large output. Feed the text via a here-string (`grep -qE -- '...' <<<"${output}"`)
+> or, better, use `expect_matches`, which relies on bash's built-in `[[ =~ ]]`
+> and spawns no subprocess at all.
 
 ## Installation and requirements
 

--- a/bashtest/README.md
+++ b/bashtest/README.md
@@ -12,5 +12,11 @@ Bashtest provides `sh_test` wrapper that simplifies the creation of shell tests.
     * expectation `expect_files_eq` "\${LHS}" "\${RHS}": Asserts that two file are the same (supports golden updates).
     * expectation `expect_contains` "\${EXPECTED}" "\${ARRAY[@]}": Assert that one string is present in an array.
     * expectation `expect_not_contains` "\${EXPECTED}" "\${ARRAY[@]}": Assert that one string is not present in an array.
+    * expectation `expect_output_contains` "\${SUBSTRING}" "\${TEXT}": Assert that a text contains a literal substring.
+    * expectation `expect_output_not_contains` "\${SUBSTRING}" "\${TEXT}": Assert that a text does not contain a literal substring.
+    * expectation `expect_matches` "\${REGEX}" "\${TEXT}": Assert that a text matches an extended regular expression (bash built-in; `^`/`$` anchor the whole text).
+    * expectation `expect_not_matches` "\${REGEX}" "\${TEXT}": Assert that a text does not match an extended regular expression.
+    * expectation `expect_pcre_matches` "\${REGEX}" "\${TEXT}": Assert that a text matches a Perl Compatible Regular Expression (requires an external PCRE tool).
+    * expectation `expect_pcre_not_matches` "\${REGEX}" "\${TEXT}": Assert that a text does not match a Perl Compatible Regular Expression.
     * special test function `test::test_init`: If present, then this function runs first! Tests will only be executed if it succeeds.
     * special test function `test::test_done`: If present, then this function runs last!

--- a/bashtest/bashtest.sh
+++ b/bashtest/bashtest.sh
@@ -70,6 +70,28 @@ Note: If long test flags are denoted with '-'s, then '_' can also be used, e.g.
 * expect_not_contains "${EXPECTED}" "${ARRAY[@]}"
                             Assert that one string is NOT present in an array.
 
+* expect_output_contains "${SUBSTRING}" "${TEXT}"
+                            Assert that a text contains a literal substring.
+
+* expect_output_not_contains "${SUBSTRING}" "${TEXT}"
+                            Assert that a text does NOT contain a substring.
+
+* expect_matches "${REGEX}" "${TEXT}"
+                            Assert that a text matches an extended regular
+                            expression (ERE). Uses bash built-in matching, so
+                            ^ and $ anchor the whole text, not each line.
+
+* expect_not_matches "${REGEX}" "${TEXT}"
+                            Assert that a text does NOT match an ERE.
+
+* expect_pcre_matches "${REGEX}" "${TEXT}"
+                            Assert that a text matches a Perl Compatible Regular
+                            Expression. Requires an external PCRE tool
+                            (grep -P, pcre2grep, or pcregrep).
+
+* expect_pcre_not_matches "${REGEX}" "${TEXT}"
+                            Assert that a text does NOT match a PCRE.
+
 
 ## Status:
 
@@ -561,4 +583,285 @@ expect_not_contains() {
         echo >&2 "  Array:    '${*}'"
         return 1
     fi
+}
+
+# Truncates a value for display in test output (mirrors expect_eq).
+_bashtest_ellipsize() {
+    local value="${1}"
+    if [[ "${#value}" -ge 50 ]]; then
+        value="${value:0:47}..."
+    fi
+    echo "${value}"
+}
+
+################################################################################
+# Assert that a text matches an extended regular expression (ERE).
+#
+# ```sh
+# expect_matches <regex> <text>
+# ```
+#
+# Matching uses bash's built-in `[[ "${text}" =~ ${regex} ]]`. No subprocess is
+# spawned, so - unlike the `printf ... | grep -qE ...` idiom - this can never
+# trigger SIGPIPE under `set -o pipefail` (which bashtest and its test scripts
+# enable).
+#
+# NOTE: `${text}` is matched as a single string, so `^` and `$` anchor the whole
+# text, NOT individual lines (this differs from `grep`, which matches per line).
+# Unanchored patterns behave the same as with `grep`.
+
+expect_matches() {
+    REGEX="${1}"
+    TEXT="${2}"
+    shift
+    shift
+    TEXT_OUT="$(_bashtest_ellipsize "${TEXT}")"
+    # NOTE: `${REGEX}` must stay unquoted so bash treats it as a pattern.
+    if [[ "${TEXT}" =~ ${REGEX} ]]; then
+        if [[ -n "${_BASHTEST_VERBOSE}" ]]; then
+            echo ""
+            echo "Test success:"
+            echo "  Expected: text matches regex: '${REGEX}'."
+        fi
+        return 0
+    else
+        _BASHTEST_HAS_ERROR=1
+        echo >&2 ""
+        echo >&2 "Test failure:"
+        echo >&2 "  Expected: text matches regex:"
+        echo >&2 "  Regex:   '${REGEX}'"
+        echo >&2 "  Text:    '${TEXT_OUT}'"
+        return 1
+    fi
+}
+
+################################################################################
+# Assert that a text does NOT match an extended regular expression (ERE).
+#
+# ```sh
+# expect_not_matches <regex> <text>
+# ```
+#
+# See `expect_matches` for the matching semantics (whole-text anchoring).
+
+expect_not_matches() {
+    REGEX="${1}"
+    TEXT="${2}"
+    shift
+    shift
+    TEXT_OUT="$(_bashtest_ellipsize "${TEXT}")"
+    # NOTE: `${REGEX}` must stay unquoted so bash treats it as a pattern.
+    if [[ "${TEXT}" =~ ${REGEX} ]]; then
+        _BASHTEST_HAS_ERROR=1
+        echo >&2 ""
+        echo >&2 "Test failure:"
+        echo >&2 "  Expected: text does NOT match regex:"
+        echo >&2 "  Regex:   '${REGEX}'"
+        echo >&2 "  Text:    '${TEXT_OUT}'"
+        return 1
+    else
+        if [[ -n "${_BASHTEST_VERBOSE}" ]]; then
+            echo ""
+            echo "Test success:"
+            echo "  Expected: text does NOT match regex: '${REGEX}'."
+        fi
+        return 0
+    fi
+}
+
+################################################################################
+# Assert that a text contains a literal substring.
+#
+# ```sh
+# expect_output_contains <substring> <text>
+# ```
+#
+# The substring is matched literally (glob metacharacters are not special). Like
+# the regex matchers this spawns no subprocess and is SIGPIPE-safe.
+
+expect_output_contains() {
+    SUBSTR="${1}"
+    TEXT="${2}"
+    shift
+    shift
+    TEXT_OUT="$(_bashtest_ellipsize "${TEXT}")"
+    if [[ "${TEXT}" == *"${SUBSTR}"* ]]; then
+        if [[ -n "${_BASHTEST_VERBOSE}" ]]; then
+            echo ""
+            echo "Test success:"
+            echo "  Expected: text contains substring: '${SUBSTR}'."
+        fi
+        return 0
+    else
+        _BASHTEST_HAS_ERROR=1
+        echo >&2 ""
+        echo >&2 "Test failure:"
+        echo >&2 "  Expected: text contains substring:"
+        echo >&2 "  Substring: '${SUBSTR}'"
+        echo >&2 "  Text:      '${TEXT_OUT}'"
+        return 1
+    fi
+}
+
+################################################################################
+# Assert that a text does NOT contain a literal substring.
+#
+# ```sh
+# expect_output_not_contains <substring> <text>
+# ```
+#
+# The substring is matched literally (glob metacharacters are not special).
+
+expect_output_not_contains() {
+    SUBSTR="${1}"
+    TEXT="${2}"
+    shift
+    shift
+    TEXT_OUT="$(_bashtest_ellipsize "${TEXT}")"
+    if [[ "${TEXT}" == *"${SUBSTR}"* ]]; then
+        _BASHTEST_HAS_ERROR=1
+        echo >&2 ""
+        echo >&2 "Test failure:"
+        echo >&2 "  Expected: text does NOT contain substring:"
+        echo >&2 "  Substring: '${SUBSTR}'"
+        echo >&2 "  Text:      '${TEXT_OUT}'"
+        return 1
+    else
+        if [[ -n "${_BASHTEST_VERBOSE}" ]]; then
+            echo ""
+            echo "Test success:"
+            echo "  Expected: text does NOT contain substring: '${SUBSTR}'."
+        fi
+        return 0
+    fi
+}
+
+################################################################################
+# PCRE matching support.
+#
+# Unlike `expect_matches`, PCRE (Perl Compatible Regular Expressions) is not a
+# bash built-in, so the PCRE matchers shell out to an external tool. Detection
+# order: `grep -P` (GNU grep), `ggrep -P` (GNU grep on macOS via Homebrew),
+# `pcre2grep`, then `pcregrep`. The result is cached in `_BASHTEST_PCRE_CMD`.
+# If no PCRE tool is available (e.g. a stock macOS install, whose BSD `grep` has
+# no `-P`), the PCRE matchers fail with an actionable message rather than
+# silently passing.
+
+_BASHTEST_PCRE_CMD=
+_BASHTEST_PCRE_CMD_SET=0
+
+# Echoes the detected PCRE command (possibly with a flag, e.g. "grep -P"), or
+# an empty string if none is available. The detection is performed only once.
+_bashtest_pcre_cmd() {
+    if [[ "${_BASHTEST_PCRE_CMD_SET}" == "1" ]]; then
+        echo "${_BASHTEST_PCRE_CMD}"
+        return 0
+    fi
+    _BASHTEST_PCRE_CMD_SET=1
+    local candidate
+    for candidate in "grep -P" "ggrep -P" "pcre2grep" "pcregrep"; do
+        # shellcheck disable=SC2086 # Intentional split: candidate may hold a flag.
+        if ${candidate} -q -e "x" <<<"x" >/dev/null 2>&1; then
+            _BASHTEST_PCRE_CMD="${candidate}"
+            break
+        fi
+    done
+    echo "${_BASHTEST_PCRE_CMD}"
+    return 0
+}
+
+# Runs the detected PCRE tool against a text via a here-string (no pipe, so it
+# cannot SIGPIPE under `set -o pipefail`). Return codes mirror grep plus one:
+#   0 = match, 1 = no match, 2 = tool/regex error, 3 = no PCRE tool available.
+_bashtest_pcre_match() {
+    local regex="${1}" text="${2}" cmd rc
+    cmd="$(_bashtest_pcre_cmd)"
+    if [[ -z "${cmd}" ]]; then
+        return 3
+    fi
+    # shellcheck disable=SC2086 # Intentional split: cmd may hold a flag.
+    if ${cmd} -q -e "${regex}" <<<"${text}"; then rc=0; else rc="${?}"; fi
+    return "${rc}"
+}
+
+################################################################################
+# Assert that a text matches a Perl Compatible Regular Expression (PCRE).
+#
+# ```sh
+# expect_pcre_matches <regex> <text>
+# ```
+#
+# Requires an external PCRE tool (see the "PCRE matching support" section). Like
+# `expect_matches`, `${text}` is matched as a single string, so `^`/`$` anchor
+# the whole text unless the pattern opts into multiline mode (e.g. `(?m)`).
+
+expect_pcre_matches() {
+    REGEX="${1}"
+    TEXT="${2}"
+    shift
+    shift
+    TEXT_OUT="$(_bashtest_ellipsize "${TEXT}")"
+    local rc
+    if _bashtest_pcre_match "${REGEX}" "${TEXT}"; then rc=0; else rc="${?}"; fi
+    if [[ "${rc}" == "0" ]]; then
+        if [[ -n "${_BASHTEST_VERBOSE}" ]]; then
+            echo ""
+            echo "Test success:"
+            echo "  Expected: text matches PCRE regex: '${REGEX}'."
+        fi
+        return 0
+    fi
+    _BASHTEST_HAS_ERROR=1
+    echo >&2 ""
+    echo >&2 "Test failure:"
+    if [[ "${rc}" == "3" ]]; then
+        echo >&2 "  Expected: text matches PCRE regex, but no PCRE tool is available."
+        echo >&2 "  Install GNU grep (grep -P), pcre2grep, or pcregrep."
+    else
+        echo >&2 "  Expected: text matches PCRE regex:"
+    fi
+    echo >&2 "  Regex:   '${REGEX}'"
+    echo >&2 "  Text:    '${TEXT_OUT}'"
+    return 1
+}
+
+################################################################################
+# Assert that a text does NOT match a Perl Compatible Regular Expression (PCRE).
+#
+# ```sh
+# expect_pcre_not_matches <regex> <text>
+# ```
+#
+# Requires an external PCRE tool (see the "PCRE matching support" section).
+
+expect_pcre_not_matches() {
+    REGEX="${1}"
+    TEXT="${2}"
+    shift
+    shift
+    TEXT_OUT="$(_bashtest_ellipsize "${TEXT}")"
+    local rc
+    if _bashtest_pcre_match "${REGEX}" "${TEXT}"; then rc=0; else rc="${?}"; fi
+    if [[ "${rc}" == "1" ]]; then
+        if [[ -n "${_BASHTEST_VERBOSE}" ]]; then
+            echo ""
+            echo "Test success:"
+            echo "  Expected: text does NOT match PCRE regex: '${REGEX}'."
+        fi
+        return 0
+    fi
+    _BASHTEST_HAS_ERROR=1
+    echo >&2 ""
+    echo >&2 "Test failure:"
+    if [[ "${rc}" == "3" ]]; then
+        echo >&2 "  Expected: text does NOT match PCRE regex, but no PCRE tool is available."
+        echo >&2 "  Install GNU grep (grep -P), pcre2grep, or pcregrep."
+    elif [[ "${rc}" == "0" ]]; then
+        echo >&2 "  Expected: text does NOT match PCRE regex, but it did:"
+    else
+        echo >&2 "  Expected: text does NOT match PCRE regex, but the tool errored:"
+    fi
+    echo >&2 "  Regex:   '${REGEX}'"
+    echo >&2 "  Text:    '${TEXT_OUT}'"
+    return 1
 }

--- a/bashtest/tests/bashtest_test.sh
+++ b/bashtest/tests/bashtest_test.sh
@@ -183,6 +183,192 @@ test::expect_not_contains() {
     _BASHTEST_NUM_SKIP="${NUM_SKIP}"
 }
 
+test::expect_output_contains() {
+    [[ "${_BASHTEST_HAS_ERROR}" == "0" ]] || bad_bashtest "Test starts with _BASHTEST_HAS_ERROR != 0, got '${_BASHTEST_HAS_ERROR}'."
+
+    NUM_PASS="${_BASHTEST_NUM_PASS}"
+    NUM_FAIL="${_BASHTEST_NUM_FAIL}"
+    NUM_SKIP="${_BASHTEST_NUM_SKIP}"
+
+    TEXT=$'line one\nSECOND line\nthird'
+
+    expect_output_contains "SECOND" "${TEXT}" || bad_bashtest "Substring is present, yet test failed."
+    _BASHTEST_HAS_ERROR=0
+
+    expect_output_contains "ECOND li" "${TEXT}" || bad_bashtest "Substring within a line is present, yet test failed."
+    _BASHTEST_HAS_ERROR=0
+
+    expect_output_contains "" "${TEXT}" || bad_bashtest "Empty substring should always be contained."
+    _BASHTEST_HAS_ERROR=0
+
+    expect_output_contains "absent" "${TEXT}" && bad_bashtest "Substring is not present, yet test passed."
+    _BASHTEST_HAS_ERROR=0
+
+    # Glob metacharacters must be treated literally.
+    expect_output_contains "a*b" "has a*b literal" || bad_bashtest "Literal '*' is present, yet test failed."
+    _BASHTEST_HAS_ERROR=0
+
+    expect_output_contains "a*b" "has aXXb glob" && bad_bashtest "'*' was treated as a glob, yet test passed."
+    _BASHTEST_HAS_ERROR=0
+
+    [[ "${_BASHTEST_NUM_PASS}" == "${NUM_PASS}" ]] || bad_bashtest "Test modified _BASHTEST_NUM_PASS."
+    [[ "${_BASHTEST_NUM_FAIL}" == "${NUM_FAIL}" ]] || bad_bashtest "Test modified _BASHTEST_NUM_FAIL."
+    [[ "${_BASHTEST_NUM_SKIP}" == "${NUM_SKIP}" ]] || bad_bashtest "Test modified _BASHTEST_NUM_SKIP."
+    _BASHTEST_NUM_PASS="${NUM_PASS}"
+    _BASHTEST_NUM_FAIL="${NUM_FAIL}"
+    _BASHTEST_NUM_SKIP="${NUM_SKIP}"
+}
+
+test::expect_output_not_contains() {
+    [[ "${_BASHTEST_HAS_ERROR}" == "0" ]] || bad_bashtest "Test starts with _BASHTEST_HAS_ERROR != 0, got '${_BASHTEST_HAS_ERROR}'."
+
+    NUM_PASS="${_BASHTEST_NUM_PASS}"
+    NUM_FAIL="${_BASHTEST_NUM_FAIL}"
+    NUM_SKIP="${_BASHTEST_NUM_SKIP}"
+
+    TEXT=$'line one\nSECOND line\nthird'
+
+    expect_output_not_contains "absent" "${TEXT}" || bad_bashtest "Substring is not present, yet test failed."
+    _BASHTEST_HAS_ERROR=0
+
+    expect_output_not_contains "SECOND" "${TEXT}" && bad_bashtest "Substring is present, yet test passed."
+    _BASHTEST_HAS_ERROR=0
+
+    expect_output_not_contains "" "${TEXT}" && bad_bashtest "Empty substring is always contained, yet test passed."
+    _BASHTEST_HAS_ERROR=0
+
+    expect_output_not_contains "a*b" "has aXXb glob" || bad_bashtest "'*' treated as glob, yet test failed."
+    _BASHTEST_HAS_ERROR=0
+
+    [[ "${_BASHTEST_NUM_PASS}" == "${NUM_PASS}" ]] || bad_bashtest "Test modified _BASHTEST_NUM_PASS."
+    [[ "${_BASHTEST_NUM_FAIL}" == "${NUM_FAIL}" ]] || bad_bashtest "Test modified _BASHTEST_NUM_FAIL."
+    [[ "${_BASHTEST_NUM_SKIP}" == "${NUM_SKIP}" ]] || bad_bashtest "Test modified _BASHTEST_NUM_SKIP."
+    _BASHTEST_NUM_PASS="${NUM_PASS}"
+    _BASHTEST_NUM_FAIL="${NUM_FAIL}"
+    _BASHTEST_NUM_SKIP="${NUM_SKIP}"
+}
+
+test::expect_matches() {
+    [[ "${_BASHTEST_HAS_ERROR}" == "0" ]] || bad_bashtest "Test starts with _BASHTEST_HAS_ERROR != 0, got '${_BASHTEST_HAS_ERROR}'."
+
+    NUM_PASS="${_BASHTEST_NUM_PASS}"
+    NUM_FAIL="${_BASHTEST_NUM_FAIL}"
+    NUM_SKIP="${_BASHTEST_NUM_SKIP}"
+
+    TEXT=$'line one\nSECOND line\nthird'
+
+    expect_matches "SECOND" "${TEXT}" || bad_bashtest "Unanchored regex is present, yet test failed."
+    _BASHTEST_HAS_ERROR=0
+
+    expect_matches "l[a-z]+ one" "${TEXT}" || bad_bashtest "ERE class should match 'line one'."
+    _BASHTEST_HAS_ERROR=0
+
+    expect_matches "^line one" "${TEXT}" || bad_bashtest "'^' should anchor the start of the text."
+    _BASHTEST_HAS_ERROR=0
+
+    expect_matches "third\$" "${TEXT}" || bad_bashtest "'\$' should anchor the end of the text."
+    _BASHTEST_HAS_ERROR=0
+
+    # Whole-text anchoring: '^SECOND' must NOT match, SECOND is not at the start.
+    expect_matches "^SECOND" "${TEXT}" && bad_bashtest "'^' must anchor the whole text, not each line."
+    _BASHTEST_HAS_ERROR=0
+
+    expect_matches "absent" "${TEXT}" && bad_bashtest "Regex is not present, yet test passed."
+    _BASHTEST_HAS_ERROR=0
+
+    expect_matches "[[:digit:]]+" "abc123" || bad_bashtest "POSIX digit class should match."
+    _BASHTEST_HAS_ERROR=0
+
+    [[ "${_BASHTEST_NUM_PASS}" == "${NUM_PASS}" ]] || bad_bashtest "Test modified _BASHTEST_NUM_PASS."
+    [[ "${_BASHTEST_NUM_FAIL}" == "${NUM_FAIL}" ]] || bad_bashtest "Test modified _BASHTEST_NUM_FAIL."
+    [[ "${_BASHTEST_NUM_SKIP}" == "${NUM_SKIP}" ]] || bad_bashtest "Test modified _BASHTEST_NUM_SKIP."
+    _BASHTEST_NUM_PASS="${NUM_PASS}"
+    _BASHTEST_NUM_FAIL="${NUM_FAIL}"
+    _BASHTEST_NUM_SKIP="${NUM_SKIP}"
+}
+
+test::expect_not_matches() {
+    [[ "${_BASHTEST_HAS_ERROR}" == "0" ]] || bad_bashtest "Test starts with _BASHTEST_HAS_ERROR != 0, got '${_BASHTEST_HAS_ERROR}'."
+
+    NUM_PASS="${_BASHTEST_NUM_PASS}"
+    NUM_FAIL="${_BASHTEST_NUM_FAIL}"
+    NUM_SKIP="${_BASHTEST_NUM_SKIP}"
+
+    TEXT=$'line one\nSECOND line\nthird'
+
+    expect_not_matches "absent" "${TEXT}" || bad_bashtest "Regex is not present, yet test failed."
+    _BASHTEST_HAS_ERROR=0
+
+    expect_not_matches "SECOND" "${TEXT}" && bad_bashtest "Regex is present, yet test passed."
+    _BASHTEST_HAS_ERROR=0
+
+    # Whole-text anchoring: '^SECOND' does not match, so not_matches should pass.
+    expect_not_matches "^SECOND" "${TEXT}" || bad_bashtest "'^SECOND' does not anchor-match, yet test failed."
+    _BASHTEST_HAS_ERROR=0
+
+    [[ "${_BASHTEST_NUM_PASS}" == "${NUM_PASS}" ]] || bad_bashtest "Test modified _BASHTEST_NUM_PASS."
+    [[ "${_BASHTEST_NUM_FAIL}" == "${NUM_FAIL}" ]] || bad_bashtest "Test modified _BASHTEST_NUM_FAIL."
+    [[ "${_BASHTEST_NUM_SKIP}" == "${NUM_SKIP}" ]] || bad_bashtest "Test modified _BASHTEST_NUM_SKIP."
+    _BASHTEST_NUM_PASS="${NUM_PASS}"
+    _BASHTEST_NUM_FAIL="${NUM_FAIL}"
+    _BASHTEST_NUM_SKIP="${NUM_SKIP}"
+}
+
+test::expect_pcre_matches() {
+    [[ "${_BASHTEST_HAS_ERROR}" == "0" ]] || bad_bashtest "Test starts with _BASHTEST_HAS_ERROR != 0, got '${_BASHTEST_HAS_ERROR}'."
+
+    NUM_PASS="${_BASHTEST_NUM_PASS}"
+    NUM_FAIL="${_BASHTEST_NUM_FAIL}"
+    NUM_SKIP="${_BASHTEST_NUM_SKIP}"
+
+    if [[ -n "$(_bashtest_pcre_cmd)" ]]; then
+        # '\d' is a PCRE-ism unavailable in bash's ERE engine.
+        expect_pcre_matches '\d+' "abc123" || bad_bashtest "PCRE '\\d+' should match digits."
+        _BASHTEST_HAS_ERROR=0
+
+        expect_pcre_matches '\d+' "no digits here" && bad_bashtest "PCRE '\\d+' matched a digitless text."
+        _BASHTEST_HAS_ERROR=0
+    else
+        echo "No PCRE tool available; verifying the matcher fails gracefully."
+        expect_pcre_matches '\d+' "abc123" && bad_bashtest "Without a PCRE tool the matcher must fail, yet it passed."
+        _BASHTEST_HAS_ERROR=0
+    fi
+
+    [[ "${_BASHTEST_NUM_PASS}" == "${NUM_PASS}" ]] || bad_bashtest "Test modified _BASHTEST_NUM_PASS."
+    [[ "${_BASHTEST_NUM_FAIL}" == "${NUM_FAIL}" ]] || bad_bashtest "Test modified _BASHTEST_NUM_FAIL."
+    [[ "${_BASHTEST_NUM_SKIP}" == "${NUM_SKIP}" ]] || bad_bashtest "Test modified _BASHTEST_NUM_SKIP."
+    _BASHTEST_NUM_PASS="${NUM_PASS}"
+    _BASHTEST_NUM_FAIL="${NUM_FAIL}"
+    _BASHTEST_NUM_SKIP="${NUM_SKIP}"
+}
+
+test::expect_pcre_not_matches() {
+    [[ "${_BASHTEST_HAS_ERROR}" == "0" ]] || bad_bashtest "Test starts with _BASHTEST_HAS_ERROR != 0, got '${_BASHTEST_HAS_ERROR}'."
+
+    NUM_PASS="${_BASHTEST_NUM_PASS}"
+    NUM_FAIL="${_BASHTEST_NUM_FAIL}"
+    NUM_SKIP="${_BASHTEST_NUM_SKIP}"
+
+    if [[ -n "$(_bashtest_pcre_cmd)" ]]; then
+        expect_pcre_not_matches '\d+' "no digits here" || bad_bashtest "PCRE '\\d+' is absent, yet not_matches failed."
+        _BASHTEST_HAS_ERROR=0
+
+        expect_pcre_not_matches '\d+' "abc123" && bad_bashtest "PCRE '\\d+' is present, yet not_matches passed."
+        _BASHTEST_HAS_ERROR=0
+    else
+        echo "No PCRE tool available; verifying the matcher fails gracefully."
+        expect_pcre_not_matches '\d+' "abc123" && bad_bashtest "Without a PCRE tool the matcher must fail, yet it passed."
+        _BASHTEST_HAS_ERROR=0
+    fi
+
+    [[ "${_BASHTEST_NUM_PASS}" == "${NUM_PASS}" ]] || bad_bashtest "Test modified _BASHTEST_NUM_PASS."
+    [[ "${_BASHTEST_NUM_FAIL}" == "${NUM_FAIL}" ]] || bad_bashtest "Test modified _BASHTEST_NUM_FAIL."
+    [[ "${_BASHTEST_NUM_SKIP}" == "${NUM_SKIP}" ]] || bad_bashtest "Test modified _BASHTEST_NUM_SKIP."
+    _BASHTEST_NUM_PASS="${NUM_PASS}"
+    _BASHTEST_NUM_FAIL="${NUM_FAIL}"
+    _BASHTEST_NUM_SKIP="${NUM_SKIP}"
+}
+
 test_runner || bad_bashtest "Test was meant to pass but did not."
 
 [[ "${_INIT_CALLED}" == "1" ]] || bad_bashtest "Test init (test::test_init) was not called."


### PR DESCRIPTION
## Why

bashtest had no matcher for "does this (multi-line) captured text match a substring/regex" — the existing string matchers are exact-equality (`expect_eq`/`expect_ne`) and array-membership (`expect_contains`). That gap forces users of CLI-output tests to hand-roll `printf '%s' "$out" | grep -qE ...`, which is a footgun under `set -o pipefail` (which `bashtest.sh` sets and its examples mandate for test scripts): `grep -q` exits on the first match, the producer takes SIGPIPE, and pipefail flips a passing test into a flaky failure on large output.

## What

Six new matchers, all following the existing matcher conventions (verbose-on-success, `_BASHTEST_HAS_ERROR` + actionable stderr on failure, 50-char display truncation):

| Matcher | Engine | Notes |
|---|---|---|
| `expect_output_contains` / `expect_output_not_contains` | `[[ == *x* ]]` | literal substring; glob metacharacters are inert |
| `expect_matches` / `expect_not_matches` | bash `[[ =~ ]]` (ERE) | zero subprocess — structurally cannot SIGPIPE; `^`/`$` anchor the whole text, not per line (documented in the help text and doc comments) |
| `expect_pcre_matches` / `expect_pcre_not_matches` | external tool | detects `grep -P` → `ggrep -P` → `pcre2grep` → `pcregrep` once and caches; text is fed via a here-string (no pipe); fails with an install hint when no backend exists |

Design notes:
- Two separately-named matchers per engine instead of an engine-selection flag: the name *is* the selector, `expect_matches` stays dependency-free/portable, and PCRE (`\d`, lookahead, non-greedy) is an explicit opt-in.
- The `output_` prefix on the substring matchers avoids collision with the array-membership `expect_contains`.
- Also documents the SIGPIPE-under-pipefail pitfall in the README and extends `bazel run //bashtest:bashtest_help`.

Backwards-compatible API addition → minor bump to 0.5.0 (MODULE.bazel + CHANGELOG).

## Testing

- New `test::` functions in `bashtest_test.sh` mirroring the existing pattern (positive/negative cases, runner-counter integrity checks). PCRE cases gate on backend availability: positive-path assertions where a backend exists (Linux CI), graceful-failure assertion on stock macOS (BSD grep has no `-P`).
- Verified matcher semantics empirically on macOS bash 3.2 (oldest supported bash), including whole-text anchoring (`^SECOND` against `$'a\nSECOND\nc'` correctly does not match), literal-glob inertness, and the positive PCRE path via `pcre2grep`.
- `bazel test //...`: 3/3 pass. shellcheck 0.11.0 clean; all pre-commit hooks pass.