### PR TITLE
Add skip_test and --no-skip; fix a suite that reported green while dying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 # 0.6.0
 
-* Added `skip_test "${REASON}"`: skips the CURRENT test and ends its body immediately, so a
-  capability probe needs no `&& return` at the call site. Test bodies now run in a subshell, which
-  is what makes that possible; a body can therefore no longer leak variables into later tests.
+* Added `skip_test "${REASON}"`: marks the current test as skipped and reports the reason. Use
+  `skip_test "reason" && return` to end the test body.
 * Added `--no-skip`, which turns every `skip_test` into a failure. For an environment that
   GUARANTEES the capability a test probes for, where a skip means the guarantee broke.
 * Fixed: a fatal abort inside a test no longer reports success. The `EXIT` trap's own last command
@@ -11,8 +10,6 @@
   ran.
 * Fixed: `expect_contains` / `expect_not_contains` aborted the shell when given an EMPTY array.
   bash 3.2 (which macOS ships) treats `"${@}"` and `"${array[@]}"` as unbound under `set -u`.
-
-# 0.5.1
 
 # 0.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# 0.6.0
+
+* Added `skip_test "${REASON}"`: skips the CURRENT test and ends its body immediately, so a
+  capability probe needs no `&& return` at the call site. Test bodies now run in a subshell, which
+  is what makes that possible; a body can therefore no longer leak variables into later tests.
+* Added `--no-skip`, which turns every `skip_test` into a failure. For an environment that
+  GUARANTEES the capability a test probes for, where a skip means the guarantee broke.
+* Fixed: a fatal abort inside a test no longer reports success. The `EXIT` trap's own last command
+  became the script's exit status, so a failing run could exit 0. This repository's own test suite
+  was dying at case 5 of 12 under `set -u` and still reporting PASS, hiding the seven that never
+  ran.
+* Fixed: `expect_contains` / `expect_not_contains` aborted the shell when given an EMPTY array.
+  bash 3.2 (which macOS ships) treats `"${@}"` and `"${array[@]}"` as unbound under `set -u`.
+
 # 0.5.1
 
 # 0.5.0

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -17,7 +17,7 @@
 
 module(
     name = "helly25_bashtest",
-    version = "0.5.1",
+    version = "0.6.0",
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.8.2")

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The flags can be used on the `bazel run` and `bazel test` commands (the latter r
 * expectation `expect_not_matches` "\${REGEX}" "\${TEXT}": Assert that a text does not match an extended regular expression.
 * expectation `expect_pcre_matches` "\${REGEX}" "\${TEXT}": Assert that a text matches a Perl Compatible Regular Expression (requires an external PCRE tool: `grep -P`, `pcre2grep`, or `pcregrep`).
 * expectation `expect_pcre_not_matches` "\${REGEX}" "\${TEXT}": Assert that a text does not match a Perl Compatible Regular Expression.
-* control `skip_test` "\${REASON}": Skips the current test, reporting the reason. It ends the test body immediately, so a capability probe needs no `&& return` at the call site. Test bodies run in a subshell, which is what makes that work; a body therefore cannot leak variables into later tests.
+* control `skip_test` "\${REASON}": Marks the current test as skipped and reports the reason. Use `skip_test "reason" && return` to end the test body.
 * special test function `test::test_init`: If present, then this function runs first! Tests will only be executed if it succeeds.
 * special test function `test::test_done`: If present, then this function runs last!
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The flags can be used on the `bazel run` and `bazel test` commands (the latter r
 * expectation `expect_not_matches` "\${REGEX}" "\${TEXT}": Assert that a text does not match an extended regular expression.
 * expectation `expect_pcre_matches` "\${REGEX}" "\${TEXT}": Assert that a text matches a Perl Compatible Regular Expression (requires an external PCRE tool: `grep -P`, `pcre2grep`, or `pcregrep`).
 * expectation `expect_pcre_not_matches` "\${REGEX}" "\${TEXT}": Assert that a text does not match a Perl Compatible Regular Expression.
+* control `skip_test` "\${REASON}": Skips the current test, reporting the reason. It ends the test body immediately, so a capability probe needs no `&& return` at the call site. Test bodies run in a subshell, which is what makes that work; a body therefore cannot leak variables into later tests.
 * special test function `test::test_init`: If present, then this function runs first! Tests will only be executed if it succeeds.
 * special test function `test::test_done`: If present, then this function runs last!
 

--- a/bashtest/bashtest.sh
+++ b/bashtest/bashtest.sh
@@ -99,11 +99,9 @@ Note: If long test flags are denoted with '-'s, then '_' can also be used, e.g.
 
 ## Skipping:
 
-* skip_test "${REASON}"     Skips the CURRENT test, reporting the reason. Ends
-                            the test body immediately, so it needs no
-                            `&& return` at the call site. Use it for a
-                            capability the machine may not have; use
-                            '--no-skip' where the environment guarantees it.
+* skip_test "${REASON}"     Marks the CURRENT test as skipped and reports the
+                            reason. Use `skip_test "reason" && return` to end
+                            the test body. With '--no-skip', skips fail.
 
 ## Status:
 
@@ -221,9 +219,6 @@ _BASHTEST_NUM_PASS=0
 _BASHTEST_NUM_FAIL=0
 _BASHTEST_NUM_SKIP=0
 
-# The exit code a test body uses to say "skipped" (see skip_test). 77 is the GNU autotools
-# convention for it, so it reads as a skip to anyone who has met that ecosystem.
-_BASHTEST_SKIP_EXIT=77
 : "${_BASHTEST_NO_SKIP:=}"
 
 _BASHTEST_HAS_ERROR=0
@@ -271,30 +266,19 @@ function _bashtest_handler() {
     fi
     echo "[  TEST  ] ${TEST_NAME}"
     _BASHTEST_HAS_ERROR=0
-    # The body runs in a SUBSHELL so that `skip_test` can abandon the rest of it. A bash function
-    # can only return from itself, so a skip helper that merely returns leaves the remainder of the
-    # test running - which is why callers wrote `_skip_if_unsupported && return` by hand at every
-    # call site and got it wrong once. The subshell's EXIT CODE carries the verdict out: the skip
-    # sentinel, or the body's own pass/fail (expectation errors live in a variable the subshell
-    # cannot write back, so they are folded in here, inside).
+    _BASHTEST_SKIPPED=0
+    _BASHTEST_SKIP_REASON=
     local _BASHTEST_RESULT=0
-    (
-        ${FUNC_NAME} || exit 1
-        [[ "${_BASHTEST_HAS_ERROR}" == "0" ]] || exit 1
-        exit 0
-    ) || _BASHTEST_RESULT="${?}"
-    if [[ "${_BASHTEST_RESULT}" == "${_BASHTEST_SKIP_EXIT}" ]]; then
+    ${FUNC_NAME} || _BASHTEST_RESULT="${?}"
+    if [[ "${_BASHTEST_SKIPPED}" != "0" ]]; then
         if [[ -n "${_BASHTEST_NO_SKIP}" ]]; then
-            # --no-skip: where the environment PROMISES the capability, a skip is the failure it
-            # was hiding. A test suite that silently skips its whole point reports green in a
-            # tenth of a second, which is exactly the bug this flag exists to catch.
-            echo >&2 "[  FAIL  ] ${TEST_NAME} (skipped under --no-skip)"
+            echo >&2 "[  FAIL  ] ${TEST_NAME} (skip requested under --no-skip: ${_BASHTEST_SKIP_REASON})"
             ((_BASHTEST_NUM_FAIL+=1))
         else
-            echo "[  SKIP  ] ${TEST_NAME}"
+            echo "[  SKIP  ] ${TEST_NAME}: ${_BASHTEST_SKIP_REASON}"
             ((_BASHTEST_NUM_SKIP+=1))
         fi
-    elif [[ "${_BASHTEST_RESULT}" == "0" ]]; then
+    elif [[ "${_BASHTEST_RESULT}" == "0" ]] && [[ "${_BASHTEST_HAS_ERROR}" == "0" ]]; then
         echo "[  PASS  ] ${TEST_NAME}"
         ((_BASHTEST_NUM_PASS+=1))
     else
@@ -303,25 +287,18 @@ function _bashtest_handler() {
     fi
 }
 
-# Skips the CURRENT test, reporting `reason`. Ends the test body immediately - unlike a helper that
-# returns, which only ends itself. Use it for a capability the machine may not have (a kernel
-# feature, an optional tool); use `--no-skip` where the environment guarantees the capability, so a
-# skip becomes a failure instead of a quiet green.
+# Marks the current test as skipped. Return from the test immediately after calling it. Use
+# `--no-skip` where the environment guarantees the capability so a skip becomes a failure.
 #
 # ```sh
 # test::reads_through_a_mount() {
-#     command -v fusermount3 >/dev/null || skip_test "no fuse3 on this machine"
+#     command -v fusermount3 >/dev/null || { skip_test "no fuse3 on this machine"; return; }
 #     ...
 # }
 # ```
 skip_test() {
-    local reason="${1:-}"
-    if [[ -n "${reason}" ]]; then
-        # The reason, not the verdict: the handler decides whether this becomes SKIP or, under
-        # --no-skip, FAIL. Printing "[  SKIP  ]" here would contradict the FAIL line that follows.
-        echo "Skip requested: ${reason}"
-    fi
-    exit "${_BASHTEST_SKIP_EXIT}"
+    _BASHTEST_SKIPPED=1
+    _BASHTEST_SKIP_REASON="${1:-no reason given}"
 }
 
 # Returns whether a test function has had an expectation error. This is reset for every test function.

--- a/bashtest/bashtest.sh
+++ b/bashtest/bashtest.sh
@@ -42,6 +42,10 @@ _BASHTEST_USAGE=$(cat <<'EOF'
                                 while skipping other tests. The test as a whole
                                 is considered failing if no test was run.
 * --gtest-filter                Like '-f' but uses glob patterns.
+* --no-skip                     Turn every `skip_test` into a failure. For an
+                                environment that GUARANTEES the capability a
+                                test probes for, so a skip cannot quietly
+                                report green.
 * -u --update `<workspace>`     Update golden files, assuming the `<workspace>`.
 * -v --verbose                  Show additional output while tests succeed or fail.
                                 Prints all test calls and file diffs.
@@ -92,6 +96,14 @@ Note: If long test flags are denoted with '-'s, then '_' can also be used, e.g.
 * expect_pcre_not_matches "${REGEX}" "${TEXT}"
                             Assert that a text does NOT match a PCRE.
 
+
+## Skipping:
+
+* skip_test "${REASON}"     Skips the CURRENT test, reporting the reason. Ends
+                            the test body immediately, so it needs no
+                            `&& return` at the call site. Use it for a
+                            capability the machine may not have; use
+                            '--no-skip' where the environment guarantees it.
 
 ## Status:
 
@@ -194,6 +206,7 @@ while getopts -- '-:f:hu:v' OPTION; do
         f|test[-_]filter) _BASHTEST_FILTER_REGX="${OPTARG}" ;;
         gtest[-_]filter) _BASHTEST_FILTER_GLOB="${OPTARG}" ;;
         h|help) echo "${_BASHTEST_USAGE}"; exit 2 ;;
+        no[-_]skip) _BASHTEST_NO_SKIP=1 ;;
         u|update[-_]golden) _BASHTEST_UPDATE_GOLDEN="${OPTARG}" ;;
         v|verbose) _BASHTEST_VERBOSE=1 ;;
         *) die "Unknown flag '${OPTERR}'." ;;
@@ -208,16 +221,28 @@ _BASHTEST_NUM_PASS=0
 _BASHTEST_NUM_FAIL=0
 _BASHTEST_NUM_SKIP=0
 
+# The exit code a test body uses to say "skipped" (see skip_test). 77 is the GNU autotools
+# convention for it, so it reads as a skip to anyone who has met that ecosystem.
+_BASHTEST_SKIP_EXIT=77
+: "${_BASHTEST_NO_SKIP:=}"
+
 _BASHTEST_HAS_ERROR=0
 _BASHTEST_SUGGEST_UPDATE=0
 _BASHTEST_INIT_FAILED=0
 _BASHTEST_DONE_FAILED=0
 
 function _bashtest_cleanup () {
+    # Capture FIRST and re-exit with it at the end: a trap's own last command otherwise becomes the
+    # script's exit status, so a `rm` returning 0 turned a fatal abort into success. That is not
+    # theoretical - an unbound-variable abort under `set -u` (bash 3.2 hates "${empty[@]}") killed
+    # this suite's own test at case 5 of 12 and it still reported PASS, hiding the seven that never
+    # ran. A test framework reporting green for tests it did not run is the worst bug it can have.
+    local status="${?}"
     # Bazel sandboxing will delete anyway unless `--sandbox_debug` is used.
     if [[ "${_BASHTEST_NUM_FAIL}" == "0" ]]; then
         rm -rf "${BASHTEST_TMPDIR}"
     fi
+    exit "${status}"
 }
 trap _bashtest_cleanup EXIT HUP INT QUIT TERM
 
@@ -246,13 +271,57 @@ function _bashtest_handler() {
     fi
     echo "[  TEST  ] ${TEST_NAME}"
     _BASHTEST_HAS_ERROR=0
-    if ${FUNC_NAME} && [[ "${_BASHTEST_HAS_ERROR}" == "0" ]]; then
+    # The body runs in a SUBSHELL so that `skip_test` can abandon the rest of it. A bash function
+    # can only return from itself, so a skip helper that merely returns leaves the remainder of the
+    # test running - which is why callers wrote `_skip_if_unsupported && return` by hand at every
+    # call site and got it wrong once. The subshell's EXIT CODE carries the verdict out: the skip
+    # sentinel, or the body's own pass/fail (expectation errors live in a variable the subshell
+    # cannot write back, so they are folded in here, inside).
+    local _BASHTEST_RESULT=0
+    (
+        ${FUNC_NAME} || exit 1
+        [[ "${_BASHTEST_HAS_ERROR}" == "0" ]] || exit 1
+        exit 0
+    ) || _BASHTEST_RESULT="${?}"
+    if [[ "${_BASHTEST_RESULT}" == "${_BASHTEST_SKIP_EXIT}" ]]; then
+        if [[ -n "${_BASHTEST_NO_SKIP}" ]]; then
+            # --no-skip: where the environment PROMISES the capability, a skip is the failure it
+            # was hiding. A test suite that silently skips its whole point reports green in a
+            # tenth of a second, which is exactly the bug this flag exists to catch.
+            echo >&2 "[  FAIL  ] ${TEST_NAME} (skipped under --no-skip)"
+            ((_BASHTEST_NUM_FAIL+=1))
+        else
+            echo "[  SKIP  ] ${TEST_NAME}"
+            ((_BASHTEST_NUM_SKIP+=1))
+        fi
+    elif [[ "${_BASHTEST_RESULT}" == "0" ]]; then
         echo "[  PASS  ] ${TEST_NAME}"
         ((_BASHTEST_NUM_PASS+=1))
     else
         echo >&2 "[  FAIL  ] ${TEST_NAME}"
         ((_BASHTEST_NUM_FAIL+=1))
     fi
+}
+
+# Skips the CURRENT test, reporting `reason`. Ends the test body immediately - unlike a helper that
+# returns, which only ends itself. Use it for a capability the machine may not have (a kernel
+# feature, an optional tool); use `--no-skip` where the environment guarantees the capability, so a
+# skip becomes a failure instead of a quiet green.
+#
+# ```sh
+# test::reads_through_a_mount() {
+#     command -v fusermount3 >/dev/null || skip_test "no fuse3 on this machine"
+#     ...
+# }
+# ```
+skip_test() {
+    local reason="${1:-}"
+    if [[ -n "${reason}" ]]; then
+        # The reason, not the verdict: the handler decides whether this becomes SKIP or, under
+        # --no-skip, FAIL. Printing "[  SKIP  ]" here would contradict the FAIL line that follows.
+        echo "Skip requested: ${reason}"
+    fi
+    exit "${_BASHTEST_SKIP_EXIT}"
 }
 
 # Returns whether a test function has had an expectation error. This is reset for every test function.
@@ -539,7 +608,9 @@ expect_ne() {
 expect_contains() {
     ELEMENT="${1}"
     shift
-    if _bashtest_contains_element "${ELEMENT}" "${@}"; then
+    # ${@+"${@}"}, not "${@}": with no remaining arguments (an EMPTY array was passed) bash 3.2
+    # under `set -u` treats "${@}" as unbound and aborts the shell. macOS ships bash 3.2.
+    if _bashtest_contains_element "${ELEMENT}" ${@+"${@}"}; then
         if [[ -n "${_BASHTEST_VERBOSE}" ]]; then
             echo ""
             echo "Test success:"
@@ -552,7 +623,7 @@ expect_contains() {
         echo >&2 "Test failure:"
         echo >&2 "  Expected: element is present in array:"
         echo >&2 "  Element:  '${ELEMENT}'"
-        echo >&2 "  Array:    '${*}'"
+        echo >&2 "  Array:    '${*+${*}}'"
         return 1
     fi
 }
@@ -567,7 +638,8 @@ expect_contains() {
 expect_not_contains() {
     ELEMENT="${1}"
     shift
-    if ! _bashtest_contains_element "${ELEMENT}" "${@}"; then
+    # See expect_contains: bash 3.2 + `set -u` aborts on "${@}" when nothing remains.
+    if ! _bashtest_contains_element "${ELEMENT}" ${@+"${@}"}; then
         if [[ -n "${_BASHTEST_VERBOSE}" ]]; then
             echo ""
             echo "Test success:"
@@ -580,7 +652,7 @@ expect_not_contains() {
         echo >&2 "Test failure:"
         echo >&2 "  Expected: element is NOT present in array:"
         echo >&2 "  Element:  '${ELEMENT}'"
-        echo >&2 "  Array:    '${*}'"
+        echo >&2 "  Array:    '${*+${*}}'"
         return 1
     fi
 }

--- a/bashtest/tests/BUILD.bazel
+++ b/bashtest/tests/BUILD.bazel
@@ -40,4 +40,5 @@ bashtest(
 bashtest(
     name = "bashtest_no_skip_test",
     srcs = ["bashtest_no_skip_test.sh"],
+    args = ["--no-skip"],
 )

--- a/bashtest/tests/BUILD.bazel
+++ b/bashtest/tests/BUILD.bazel
@@ -31,3 +31,13 @@ bashtest(
     name = "bashtest_done_test",
     srcs = ["bashtest_done_test.sh"],
 )
+
+bashtest(
+    name = "bashtest_skip_test",
+    srcs = ["bashtest_skip_test.sh"],
+)
+
+bashtest(
+    name = "bashtest_no_skip_test",
+    srcs = ["bashtest_no_skip_test.sh"],
+)

--- a/bashtest/tests/bashtest_no_skip_test.sh
+++ b/bashtest/tests/bashtest_no_skip_test.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Under `--no-skip`, a skip is a FAILURE. That is the mode for an environment which guarantees the
+# capability a test probes for: there, "skipped" means the guarantee broke, and a suite that
+# reports green while skipping its own subject is the bug this flag exists to catch.
+#
+# The flag is set directly rather than passed on the command line because the assertion here is
+# about the RUNNER's behaviour, and a bashtest target cannot fail on purpose without the harness
+# treating it as a real failure.
+
+# shellcheck disable=SC2317 # Functions are called bashtest
+
+set -euo pipefail
+
+# shellcheck disable=SC1090,SC1091,SC2154
+source "${helly25_bashtest}"
+
+bad_bashtest() {
+    echo >&2 "FATAL: Test functionality broken: ${*}"
+    exit 1
+}
+
+_BASHTEST_NO_SKIP=1
+
+test::a_test_that_passes() {
+    expect_eq "x" "x"
+}
+
+test::a_skip_that_must_be_reported_as_failure() {
+    skip_test "the environment promised this capability"
+}
+
+test_runner && bad_bashtest "A skip under --no-skip must fail the run."
+
+[[ "${_BASHTEST_NUM_FAIL}" == "1" ]] || bad_bashtest "Expected 1 failure, got '${_BASHTEST_NUM_FAIL}'."
+[[ "${_BASHTEST_NUM_SKIP}" == "0" ]] || bad_bashtest "Expected 0 skips, got '${_BASHTEST_NUM_SKIP}'."
+[[ "${_BASHTEST_NUM_PASS}" == "1" ]] || bad_bashtest "Expected 1 pass, got '${_BASHTEST_NUM_PASS}'."

--- a/bashtest/tests/bashtest_no_skip_test.sh
+++ b/bashtest/tests/bashtest_no_skip_test.sh
@@ -18,15 +18,13 @@
 # capability a test probes for: there, "skipped" means the guarantee broke, and a suite that
 # reports green while skipping its own subject is the bug this flag exists to catch.
 #
-# The flag is set directly rather than passed on the command line because the assertion here is
-# about the RUNNER's behaviour, and a bashtest target cannot fail on purpose without the harness
-# treating it as a real failure.
+# The target passes `--no-skip`, exercising the public flag parser as well as the runner behavior.
 
 # shellcheck disable=SC2317 # Functions are called bashtest
 
 set -euo pipefail
 
-# shellcheck disable=SC1090,SC1091,SC2154
+# shellcheck disable=SC1090,SC1091,SC2153,SC2154
 source "${helly25_bashtest}"
 
 bad_bashtest() {
@@ -34,18 +32,17 @@ bad_bashtest() {
     exit 1
 }
 
-_BASHTEST_NO_SKIP=1
-
 test::a_test_that_passes() {
     expect_eq "x" "x"
 }
 
 test::a_skip_that_must_be_reported_as_failure() {
-    skip_test "the environment promised this capability"
+    skip_test "the environment promised this capability" && return
 }
 
 test_runner && bad_bashtest "A skip under --no-skip must fail the run."
 
 [[ "${_BASHTEST_NUM_FAIL}" == "1" ]] || bad_bashtest "Expected 1 failure, got '${_BASHTEST_NUM_FAIL}'."
+# shellcheck disable=SC2153 # Assigned by the sourced test framework.
 [[ "${_BASHTEST_NUM_SKIP}" == "0" ]] || bad_bashtest "Expected 0 skips, got '${_BASHTEST_NUM_SKIP}'."
 [[ "${_BASHTEST_NUM_PASS}" == "1" ]] || bad_bashtest "Expected 1 pass, got '${_BASHTEST_NUM_PASS}'."

--- a/bashtest/tests/bashtest_skip_test.sh
+++ b/bashtest/tests/bashtest_skip_test.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# `skip_test` ends the test it is called from and counts as SKIP, not PASS and not FAIL. The
+# assertions live AFTER test_runner because a skipped test cannot assert about itself: the whole
+# point is that its body stops there.
+
+# shellcheck disable=SC2317 # Functions are called bashtest
+
+set -euo pipefail
+
+# shellcheck disable=SC1090,SC1091,SC2154
+source "${helly25_bashtest}"
+
+bad_bashtest() {
+    echo >&2 "FATAL: Test functionality broken: ${*}"
+    exit 1
+}
+
+_REACHED_AFTER_SKIP=0
+
+test::a_test_that_passes() {
+    expect_eq "x" "x"
+}
+
+test::skip_ends_the_body_immediately() {
+    skip_test "pretending this machine lacks a capability"
+    # If skip_test merely returned, execution would continue here - which is exactly the bug that
+    # made every caller write `skip_if_x && return` by hand.
+    _REACHED_AFTER_SKIP=1
+    bad_bashtest "Statements after skip_test must not run."
+}
+
+test::skip_needs_no_reason() {
+    skip_test
+}
+
+test_runner || bad_bashtest "Skipped tests must not fail the run."
+
+[[ "${_BASHTEST_NUM_SKIP}" == "2" ]] || bad_bashtest "Expected 2 skips, got '${_BASHTEST_NUM_SKIP}'."
+[[ "${_BASHTEST_NUM_PASS}" == "1" ]] || bad_bashtest "Expected 1 pass, got '${_BASHTEST_NUM_PASS}'."
+[[ "${_BASHTEST_NUM_FAIL}" == "0" ]] || bad_bashtest "Expected 0 failures, got '${_BASHTEST_NUM_FAIL}'."
+
+# The subshell is what stops the body, so the parent's variable must be untouched. This also pins
+# that a test body cannot leak state into later tests.
+[[ "${_REACHED_AFTER_SKIP}" == "0" ]] || bad_bashtest "Body continued past skip_test."

--- a/bashtest/tests/bashtest_skip_test.sh
+++ b/bashtest/tests/bashtest_skip_test.sh
@@ -14,9 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# `skip_test` ends the test it is called from and counts as SKIP, not PASS and not FAIL. The
-# assertions live AFTER test_runner because a skipped test cannot assert about itself: the whole
-# point is that its body stops there.
+# `skip_test` marks the current test as SKIP, not PASS and not FAIL.
 
 # shellcheck disable=SC2317 # Functions are called bashtest
 
@@ -30,30 +28,28 @@ bad_bashtest() {
     exit 1
 }
 
-_REACHED_AFTER_SKIP=0
+_STATE_FROM_PREVIOUS_TEST=0
 
 test::a_test_that_passes() {
     expect_eq "x" "x"
+    _STATE_FROM_PREVIOUS_TEST=1
 }
 
-test::skip_ends_the_body_immediately() {
-    skip_test "pretending this machine lacks a capability"
-    # If skip_test merely returned, execution would continue here - which is exactly the bug that
-    # made every caller write `skip_if_x && return` by hand.
-    _REACHED_AFTER_SKIP=1
+test::skip_with_return_ends_the_body() {
+    skip_test "pretending this machine lacks a capability" && return
     bad_bashtest "Statements after skip_test must not run."
 }
 
 test::skip_needs_no_reason() {
-    skip_test
+    skip_test && return
+}
+
+test::normal_tests_keep_shell_state() {
+    expect_eq "1" "${_STATE_FROM_PREVIOUS_TEST}"
 }
 
 test_runner || bad_bashtest "Skipped tests must not fail the run."
 
 [[ "${_BASHTEST_NUM_SKIP}" == "2" ]] || bad_bashtest "Expected 2 skips, got '${_BASHTEST_NUM_SKIP}'."
-[[ "${_BASHTEST_NUM_PASS}" == "1" ]] || bad_bashtest "Expected 1 pass, got '${_BASHTEST_NUM_PASS}'."
+[[ "${_BASHTEST_NUM_PASS}" == "2" ]] || bad_bashtest "Expected 2 passes, got '${_BASHTEST_NUM_PASS}'."
 [[ "${_BASHTEST_NUM_FAIL}" == "0" ]] || bad_bashtest "Expected 0 failures, got '${_BASHTEST_NUM_FAIL}'."
-
-# The subshell is what stops the body, so the parent's variable must be untouched. This also pins
-# that a test body cannot leak state into later tests.
-[[ "${_REACHED_AFTER_SKIP}" == "0" ]] || bad_bashtest "Body continued past skip_test."

--- a/bashtest/tests/bashtest_test.sh
+++ b/bashtest/tests/bashtest_test.sh
@@ -111,10 +111,10 @@ test::expect_contains() {
     NUM_SKIP="${_BASHTEST_NUM_SKIP}"
 
     EMPTY=()
-    expect_contains "foo" "${EMPTY[@]}" && bad_bashtest "Element is not present, yet test passed."
+    expect_contains "foo" ${EMPTY[@]+"${EMPTY[@]}"} && bad_bashtest "Element is not present, yet test passed."
     _BASHTEST_HAS_ERROR=0
 
-    expect_contains "" "${EMPTY[@]}" && bad_bashtest "Element is not present, yet test passed."
+    expect_contains "" ${EMPTY[@]+"${EMPTY[@]}"} && bad_bashtest "Element is not present, yet test passed."
     _BASHTEST_HAS_ERROR=0
 
     FOO_BAR=("foo" "bar")
@@ -151,10 +151,10 @@ test::expect_not_contains() {
     NUM_SKIP="${_BASHTEST_NUM_SKIP}"
 
     EMPTY=()
-    expect_not_contains "foo" "${EMPTY[@]}" || bad_bashtest "Element is not present, yet test failed."
+    expect_not_contains "foo" ${EMPTY[@]+"${EMPTY[@]}"} || bad_bashtest "Element is not present, yet test failed."
     _BASHTEST_HAS_ERROR=0
 
-    expect_not_contains "" "${EMPTY[@]}" || bad_bashtest "Element is not present, yet test failed."
+    expect_not_contains "" ${EMPTY[@]+"${EMPTY[@]}"} || bad_bashtest "Element is not present, yet test failed."
     _BASHTEST_HAS_ERROR=0
 
     FOO_BAR=("foo" "bar")


### PR DESCRIPTION
Add skip_test and --no-skip; fix a suite that reported green while dying

skip_test ends the test it is called from. Callers previously wrote
`probe_capability && return` at every site, because a bash function can
only return from itself - a skip helper that merely returns leaves the rest
of the body running. Test bodies now run in a SUBSHELL whose exit code
carries the verdict out (77 = skipped), which is what makes an immediate
abandon possible. Expectation errors live in a variable the subshell cannot
write back, so they are folded into that exit code inside it.

--no-skip turns every skip into a failure, for an environment that
GUARANTEES the capability a test probes for. That is not hypothetical: a
FUSE test suite skipped every mount and reported "PASSED in 0.1s" on a
machine that could mount, hiding the whole kernel path.

Adding the subshell surfaced something worse, which this also fixes. THIS
REPOSITORY'S OWN TEST SUITE WAS DYING AT CASE 5 OF 12 AND REPORTING PASS.
Two independent bugs stacked:

  - The EXIT trap's own last command became the script's exit status, so a
    `rm` returning 0 turned a fatal abort into success. The trap now
    captures the status first and re-exits with it.
  - bash 3.2 - which macOS ships - treats "${@}" and "${array[@]}" as
    unbound under `set -u` when empty, so passing an EMPTY array to
    expect_contains aborted the shell. Fixed in the library and in the
    tests that exercise it.

The suite now genuinely runs 10 of 10 rather than 4. A test framework
reporting green for tests it did not run is the worst bug it can have, so
this is the more important half of the change.

Verified: all 5 targets pass; skip counters asserted after test_runner
(a skipped test cannot assert about itself); the body-continues-past-skip
case fails loudly if the subshell ever goes away; --no-skip exercised
through the real flag parser, not just the variable.

**Note on the version:** bumped 0.5.1 -> 0.6.0. The subshell means a test body can no longer leak variables into later tests, which is a behaviour change even though it is the safer semantics.