### PR TITLE
Transfer bashtest module to MBO Works

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,5 +1,5 @@
 {
-  "homepage": "https://github.com/helly25/bashtest",
+  "homepage": "https://github.com/mboworks/bashtest",
   "maintainers": [
     {
       "name": "helly25",
@@ -8,7 +8,7 @@
     }
   ],
   "repository": [
-    "github:helly25/bashtest"
+    "github:mboworks/bashtest"
   ],
   "versions": [],
   "yanked_versions": {}

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -15,4 +15,4 @@ tasks:
     platform: ${{ platform }}
     bazel: ${{ bazel }}
     build_targets:
-      - '@helly25_bashtest//bashtest/...'
+      - '@mboworks_bashtest//bashtest/...'

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# All repository changes are owned by the MBO Works maintainers. GitHub
+# requires approval from any one listed owner when code-owner review is enabled;
+# the pull request author cannot approve their own change.
+* @helly25 @Fab-Cat

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
       - uses: actions/setup-python@v5
         with:
           python-version: 3.11

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,10 +8,12 @@ jobs:
   release:
     uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7
     permissions:
+      attestations: write
       contents: write
+      id-token: write
     with:
       release_files: bashtest-*.tar.gz
-      prerelease: true
+      prerelease: false
 
   # Mirror the release to the Bazel Central Registry (replaces the retired
   # publish-to-bcr GitHub App). See .github/workflows/publish.yaml.

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -27,7 +27,7 @@ function die() {
 
 # Custom args to update as needed.
 PACKAGE_NAME="bashtest"
-BAZELMOD_NAME="helly25_bashtest"
+BAZELMOD_NAME="mboworks_bashtest"
 PATCHES=()
 
 # Automatic vars from workflow integration.
@@ -99,7 +99,7 @@ git archive --format=tar.gz --prefix="${PREFIX}/" -o "${ARCHIVE}" --add-virtual-
 
 # Print header
 echo "# Version ${VERSION}"
-echo "## [Changelog](https://github.com/helly25/${PACKAGE_NAME}/blob/${TAG}/CHANGELOG.md)"
+echo "## [Changelog](https://github.com/mboworks/${PACKAGE_NAME}/blob/${TAG}/CHANGELOG.md)"
 
 # Print Changelog
 awk '/^#/{f+=1;if(f>1)exit} !/^#/{print}' <CHANGELOG.md

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,11 +40,12 @@ repos:
   - id: compare-versions
     name: compare-versions
     description: |
-      Compare the versions in CHANGELOG.md and MODULES.bazel.
+      Require matching CHANGELOG.md and MODULE.bazel versions. After a release,
+      the first later commit must advance both beyond the latest release tag.
     language: system
     entry: .pre-commit/check_version.sh
     pass_filenames: False
-    types: [text]
+    always_run: true
   - id: no-do-not-merge
     name: No 'DO NOT MERGE'
     description: |
@@ -61,7 +62,7 @@ repos:
     description: |
       * Use descriptive, referenceable TODOs. Examples:
         * `// TODO(nero.windstriker@helly25.com)`
-        * `# FIXME(https://github.com/helly25/bzl/issues/42)`
+        * `# FIXME(https://github.com/mboworks/bashtest/issues/42)`
       * From the google style guide:
         Use FIXME/TODO comments for code that is temporary, a short-term solution.
         FIXME/TODOs should include the string `FIXME` or `TODO` in all caps, followed by a person's

--- a/.pre-commit/check_version.sh
+++ b/.pre-commit/check_version.sh
@@ -15,11 +15,46 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -euo pipefail
+
 function die() { echo "ERROR: ${*}" 1>&2 ; exit 1; }
+
+function version_key() {
+    local version="${1}"
+    awk -F. '{ printf "%010d%010d%010d\n", $1, $2, $3 }' <<<"${version}"
+}
 
 BAZELMOD_VERSION="$(sed -rne 's,.*version = "([0-9]+([.][0-9]+)+.*)".*,\1,p' < MODULE.bazel|head -n1)"
 CHANGELOG_VERSION="$(sed -rne 's,^# ([0-9]+([.][0-9]+)+.*)$,\1,p' < CHANGELOG.md|head -n1)"
 
 if [ "${BAZELMOD_VERSION}" != "${CHANGELOG_VERSION}" ]; then
     die "MODULE.bazel (${BAZELMOD_VERSION}) != CHANGELOG.md (${CHANGELOG_VERSION})."
+fi
+
+if [[ ! "${BAZELMOD_VERSION}" =~ ^(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)$ ]]; then
+    die "MODULE.bazel version (${BAZELMOD_VERSION}) must use numeric X.Y.Z format."
+fi
+
+LATEST_RELEASE="$(
+    git tag --list |
+        awk '/^(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)$/' |
+        while read -r version; do
+            printf '%s %s\n' "$(version_key "${version}")" "${version}"
+        done |
+        sort |
+        tail -n1 |
+        awk '{ print $2 }'
+)"
+
+if [[ -n "${LATEST_RELEASE}" ]] &&
+[[ "$(version_key "${BAZELMOD_VERSION}")" < "$(version_key "${LATEST_RELEASE}")" ]]; then
+    die "Development version (${BAZELMOD_VERSION}) is older than latest release tag (${LATEST_RELEASE})."
+fi
+
+# Equality is valid while main still points at the released commit. The first
+# subsequent commit (normally the next PR) must advance the development version.
+if [[ -n "${LATEST_RELEASE}" ]] &&
+[[ "${BAZELMOD_VERSION}" == "${LATEST_RELEASE}" ]] &&
+[[ "$(git rev-parse HEAD)" != "$(git rev-list -n1 "${LATEST_RELEASE}")" ]]; then
+    die "Development version (${BAZELMOD_VERSION}) still matches latest release tag (${LATEST_RELEASE}), but HEAD contains later work. Bump MODULE.bazel and CHANGELOG.md."
 fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # 0.6.1
 
+* Transferred the canonical repository from `helly25/bashtest` to
+  `mboworks/bashtest`; future releases use the new `mboworks_bashtest` module
+  name.
+* Added managed per-fixture scratch directories through `test_tmpdir`, with
+  configurable retention and cleanup.
+
 # 0.6.0
 
 * Added `skip_test "${REASON}"`: marks the current test as skipped and reports the reason. Use

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,10 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Module helly25_bashtest"""
+"""Module mboworks_bashtest"""
 
 module(
-    name = "helly25_bashtest",
+    name = "mboworks_bashtest",
     version = "0.6.1",
 )
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This shell test library provides Bazel macro rules to simplify shell testing.
 
-The library is tested with continuous integration: [![Test](https://github.com/helly25/bashtest/actions/workflows/main.yml/badge.svg)](https://github.com/helly25/bashtest/actions/workflows/main.yml).
+The library is tested with continuous integration: [![Test](https://github.com/mboworks/bashtest/actions/workflows/main.yml/badge.svg)](https://github.com/mboworks/bashtest/actions/workflows/main.yml).
 
 ## Bashtest
 
@@ -46,7 +46,7 @@ locally or with `--sandbox_debug`.
 set -euo pipefail
 
 # shellcheck disable=SC1090,SC1091,SC2154
-source "${helly25_bashtest}"
+source "${mboworks_bashtest}"
 
 test::my_test() {
   expect_ne "Hello" "World"
@@ -61,7 +61,7 @@ test_runner
 2) Write or extend a BUILD file
 
 ```bzl
-load("@helly25_bashtest//bashtest:bashtest.bzl", "bashtest")
+load("@mboworks_bashtest//bashtest:bashtest.bzl", "bashtest")
 
 bashtest(
     name = "sh_test",
@@ -90,8 +90,8 @@ This repository requires bash to work (Linux, MacOs).
 
 ### MODULE.bazel
 
-Check [Releases](https://github.com/helly25/bashtest/releases) for details. All that is needed is a `bazel_dep` instruction with the correct version.
+Check [Releases](https://github.com/mboworks/bashtest/releases) for details. All that is needed is a `bazel_dep` instruction with the correct version.
 
 ```
-bazel_dep(name = "helly25_bashtest", version = "0.0.0")
+bazel_dep(name = "mboworks_bashtest", version = "0.0.0")
 ```

--- a/bashtest/README.md
+++ b/bashtest/README.md
@@ -1,4 +1,4 @@
-# helly25_bashtest//bashtest
+# mboworks_bashtest//bashtest
 
 Bashtest provides `sh_test` wrapper that simplifies the creation of shell tests.
 

--- a/bashtest/bashtest.bzl
+++ b/bashtest/bashtest.bzl
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""helly25_bashtest/bashtest:bashtest"""
+"""mboworks_bashtest/bashtest:bashtest"""
 
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 
@@ -21,7 +21,7 @@ load("@rules_shell//shell:sh_test.bzl", "sh_test")
 # constructed in a `.bzl` file is resolved against the repo that defines the
 # file, so the macro works no matter what apparent repo name a consumer assigns
 # it (and under both bzlmod and the legacy WORKSPACE setup). This is what lets
-# the module be named `helly25_bashtest` without a `com_helly25_bashtest` alias.
+# the module to work without an apparent repository-name alias.
 _BASHTEST_SH = Label("//bashtest:bashtest_sh")
 
 def bashtest(
@@ -32,7 +32,7 @@ def bashtest(
     """Bashtest wrapper.
 
     Specialized `sh_shell` rule to simplify `bashtest` usage. The rule provides
-    the `helly25_bashtest` environement variable that should
+    the `mboworks_bashtest` environment variable that should
     be used in test scripts to source the `bashtest.sh` script as follows:
 
     * File: sh_test.sh
@@ -41,7 +41,7 @@ def bashtest(
     set -euo pipefail
 
     # shellcheck disable=SC1090,SC1091,SC2154
-    source "${helly25_bashtest}"
+    source "${mboworks_bashtest}"
 
     test::my_test() {
       expect_ne "Hello" "World"
@@ -56,7 +56,7 @@ def bashtest(
     * File: BUILD
 
     ```bzl
-    load("@helly25_bashtest//bashtest:bashtest.bzl", "bashtest")
+    load("@mboworks_bashtest//bashtest:bashtest.bzl", "bashtest")
 
     bashtest(
         name = "sh_test",
@@ -67,12 +67,12 @@ def bashtest(
     Args:
         name:      Name of the test rule. Should end in `_test`
         deps:      Dependencies which will have bashtest_sh automatically added.
-        env:       Environmentname that automatically adds `helly25_bashtest`.
+        env:       Environment name that automatically adds `mboworks_bashtest`.
         **kwargs:  All other attributes are passed through as is.
     """
 
     extra_env = {
-        "helly25_bashtest": "$(rootpath {label})".format(label = _BASHTEST_SH),
+        "mboworks_bashtest": "$(rootpath {label})".format(label = _BASHTEST_SH),
     }
     sh_test(
         name = name,

--- a/bashtest/bashtest.sh
+++ b/bashtest/bashtest.sh
@@ -134,7 +134,7 @@ Note: If long test flags are denoted with '-'s, then '_' can also be used, e.g.
 set -euo pipefail
 
 # shellcheck disable=SC1090,SC1091,SC2154 # Source via magic bahtest variable
-source "${helly25_bashtest}"
+source "${mboworks_bashtest}"
 
 function test::hello() {
     expect_ne "Hello" "World"
@@ -146,7 +146,7 @@ test_runner
 In your BUILD file:
 
 ```bzl
-load ("@helly25_bashtest//bashtest:bashtest.bzl", "bashtest")
+load ("@mboworks_bashtest//bashtest:bashtest.bzl", "bashtest")
 
 bashtest(
     name = "my_test",

--- a/bashtest/tests/bashtest_done_test.sh
+++ b/bashtest/tests/bashtest_done_test.sh
@@ -20,7 +20,7 @@
 set -euo pipefail
 
 # shellcheck disable=SC1090,SC1091,SC2154
-source "${helly25_bashtest}"
+source "${mboworks_bashtest}"
 
 bad_bashtest() {
     echo >&2 "FATAL: Test functionality broken: ${*}"

--- a/bashtest/tests/bashtest_init_test.sh
+++ b/bashtest/tests/bashtest_init_test.sh
@@ -20,7 +20,7 @@
 set -euo pipefail
 
 # shellcheck disable=SC1090,SC1091,SC2154
-source "${helly25_bashtest}"
+source "${mboworks_bashtest}"
 
 bad_bashtest() {
     echo >&2 "FATAL: Test functionality broken: ${*}"

--- a/bashtest/tests/bashtest_no_skip_test.sh
+++ b/bashtest/tests/bashtest_no_skip_test.sh
@@ -25,7 +25,7 @@
 set -euo pipefail
 
 # shellcheck disable=SC1090,SC1091,SC2153,SC2154
-source "${helly25_bashtest}"
+source "${mboworks_bashtest}"
 
 bad_bashtest() {
     echo >&2 "FATAL: Test functionality broken: ${*}"

--- a/bashtest/tests/bashtest_skip_test.sh
+++ b/bashtest/tests/bashtest_skip_test.sh
@@ -21,7 +21,7 @@
 set -euo pipefail
 
 # shellcheck disable=SC1090,SC1091,SC2154
-source "${helly25_bashtest}"
+source "${mboworks_bashtest}"
 
 bad_bashtest() {
     echo >&2 "FATAL: Test functionality broken: ${*}"

--- a/bashtest/tests/bashtest_test.sh
+++ b/bashtest/tests/bashtest_test.sh
@@ -20,7 +20,7 @@
 set -euo pipefail
 
 # shellcheck disable=SC1090,SC1091,SC2154
-source "${helly25_bashtest}"
+source "${mboworks_bashtest}"
 
 
 bad_bashtest() {

--- a/tools/trigger_release.sh
+++ b/tools/trigger_release.sh
@@ -2,223 +2,51 @@
 
 # SPDX-FileCopyrightText: Copyright (c) The helly25 authors (helly25.com)
 # SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 set -euo pipefail
 
-function die() { echo "ERROR: ${*}" 1>&2 ; exit 1; }
-
-function usage() {
-    cat <<EOF
-Usage: ${0} [--dry-run] <command> <version>
-
-<version> is the released version, i.e. the version currently present in
-MODULE.bazel and CHANGELOG.md.
-
-Commands:
-  tag       Create and push the signed release tag for <version>.
-  bump      Open a PR that bumps <version> to the next patch version. Use this
-            on its own to recover when 'tag' succeeded but the bump did not.
-  release   Run 'tag' then 'bump' (the full release flow).
-
-Options:
-  --dry-run, --dry, --dry-mode   Print the mutating actions instead of
-                                 performing them. Read-only validations still
-                                 run, but failing preconditions are downgraded
-                                 to warnings so the full flow can be previewed.
-  -h, --help                     Show this help and exit.
-EOF
+function die() {
+    echo "ERROR: ${*}" 1>&2
+    exit 1
 }
 
-DRY_RUN=0
-COMMAND=""
+DRY_RUN=false
 VERSION=""
 for arg in "${@}"; do
     case "${arg}" in
-        --dry-run|--dry|--dry-mode) DRY_RUN=1 ;;
-        -h|--help) usage; exit 0 ;;
-        -*) usage 1>&2; die "Unknown flag: '${arg}'." ;;
+        --dry|--dry-run) DRY_RUN=true ;;
+        -*) die "Unknown option '${arg}'. Usage: ${0} [--dry-run] <version>" ;;
         *)
-            if [[ -z "${COMMAND}" ]]; then
-                COMMAND="${arg}"
-            elif [[ -z "${VERSION}" ]]; then
-                VERSION="${arg}"
-            else
-                usage 1>&2; die "Unexpected argument: '${arg}'."
-            fi
+            [[ -z "${VERSION}" ]] || die "Usage: ${0} [--dry-run] <version>"
+            VERSION="${arg}"
             ;;
     esac
 done
+[[ -n "${VERSION}" ]] || die "Usage: ${0} [--dry-run] <version>"
 
-case "${COMMAND}" in
-    tag|bump|release) ;;
-    "") usage 1>&2; die "Must provide a command (tag|bump|release)." ;;
-    *) usage 1>&2; die "Unknown command: '${COMMAND}'." ;;
-esac
+for tool in gh git gpg; do
+    command -v "${tool}" >/dev/null 2>&1 || die "Required tool '${tool}' is not installed."
+done
 
-[[ -n "${VERSION}" ]] || { usage 1>&2; die "Must provide a version argument."; }
+git fetch origin main --tags
+[[ "$(git branch --show-current)" == "main" ]] || die "Must be run from main."
+[[ -z "$(git status --porcelain)" ]] || die "Working tree must be clean."
+[[ "$(git rev-parse HEAD)" == "$(git rev-parse origin/main)" ]] || die "Local main must equal origin/main."
 
-# Runs a mutating command, or just prints it when in dry-run mode.
-function run() {
-    if [[ ${DRY_RUN} == 1 ]]; then
-        echo "DRY-RUN: ${*}" 1>&2
-    else
-        "${@}"
-    fi
-}
+BAZELMOD_VERSION="$(sed -rne 's,.*version = "([0-9]+([.][0-9]+)+.*)".*,\1,p' MODULE.bazel | head -n1)"
+CHANGELOG_VERSION="$(sed -rne 's,^# ([0-9]+([.][0-9]+)+.*)$,\1,p' CHANGELOG.md | head -n1)"
+[[ "${BAZELMOD_VERSION}" == "${CHANGELOG_VERSION}" ]] || die "MODULE.bazel (${BAZELMOD_VERSION}) != CHANGELOG.md (${CHANGELOG_VERSION})."
+[[ "${VERSION}" == "${BAZELMOD_VERSION}" ]] || die "Requested version (${VERSION}) != repository version (${BAZELMOD_VERSION})."
+[[ -z "$(git tag --list "${VERSION}")" ]] || die "Tag '${VERSION}' already exists."
+gh release view "${VERSION}" >/dev/null 2>&1 && die "Release '${VERSION}' already exists."
 
-# Fails a precondition. In dry-run mode this is downgraded to a warning so the
-# rest of the flow can still be previewed.
-function check_fail() {
-    if [[ ${DRY_RUN} == 1 ]]; then
-        echo "WARNING (ignored in dry-run): ${*}" 1>&2
-    else
-        die "${*}"
-    fi
-}
+if [[ "${DRY_RUN}" == true ]]; then
+    echo "[dry-run] Would create and push signed tag '${VERSION}' at $(git rev-parse HEAD)."
+    exit 0
+fi
 
-# Validates the working tree and version consistency, and sets the global
-# BAZELMOD_VERSION, CHANGELOG_VERSION and NEXT_VERSION.
-function validate() {
-    git fetch origin main  # Make sure the below is relevant.
-
-    if [[ -n "$(git status --porcelain)" ]]; then
-        # Non empty output means non clean branch.
-        check_fail "Must be run from clean 'main' branch."
-    fi
-    if [[ -n "$(git diff origin/main --numstat)" ]]; then
-        check_fail "Must be run from clean 'main' branch."
-    fi
-    if [[ -n "$(git diff origin/main --cached --numstat)" ]]; then
-        check_fail "Must be run from clean 'main' branch."
-    fi
-
-    BAZELMOD_VERSION="$(sed -rne 's,.*version = "([0-9]+([.][0-9]+)+.*)".*,\1,p' < MODULE.bazel|head -n1)"
-    CHANGELOG_VERSION="$(sed -rne 's,^# ([0-9]+([.][0-9]+)+.*)$,\1,p' < CHANGELOG.md|head -n1)"
-    NEXT_VERSION="$(echo "${VERSION}"|awk -F. '/^(0|[1-9][0-9]*)([.](0|[1-9][0-9]*)){2,}([-+]|$)/{print $1"."$2"."(($3)+1)}')"
-
-    if [[ "${BAZELMOD_VERSION}" != "${CHANGELOG_VERSION}" ]]; then
-        check_fail "MODULE.bazel (${BAZELMOD_VERSION}) != CHANGELOG.md (${CHANGELOG_VERSION})."
-    fi
-
-    if [[ "${VERSION}" != "${BAZELMOD_VERSION}" ]]; then
-        check_fail "Provided version argument (${VERSION}) different from merged version (${BAZELMOD_VERSION})."
-    fi
-
-    if [[ -z "${NEXT_VERSION}" ]]; then
-        die "Could not determine next version from input (${VERSION})."
-    fi
-}
-
-# Replaces the first `version = "${VERSION}"` in MODULE.bazel with the next
-# version. Portable (no GNU-only `sed -i` / `0,/re/` address).
-function bump_module_version() {
-    if [[ ${DRY_RUN} == 1 ]]; then
-        echo "DRY-RUN: bump MODULE.bazel version '${VERSION}' -> '${NEXT_VERSION}'." 1>&2
-        return
-    fi
-    awk -v old="${VERSION}" -v new="${NEXT_VERSION}" '
-        !done && index($0, "version = \"" old "\"") {
-            sub("version = \"" old "\"", "version = \"" new "\"")
-            done = 1
-        }
-        { print }
-    ' MODULE.bazel > MODULE.bazel.tmp && mv MODULE.bazel.tmp MODULE.bazel
-}
-
-# Prepends a new (empty) changelog section for the next version. Portable.
-function prepend_changelog() {
-    if [[ ${DRY_RUN} == 1 ]]; then
-        echo "DRY-RUN: prepend section '# ${NEXT_VERSION}' to CHANGELOG.md." 1>&2
-        return
-    fi
-    { printf '# %s\n\n' "${NEXT_VERSION}"; cat CHANGELOG.md; } > CHANGELOG.md.tmp \
-        && mv CHANGELOG.md.tmp CHANGELOG.md
-}
-
-# Creates and pushes the signed release tag for ${VERSION}.
-function do_tag() {
-    if git tag -l | grep -qFx "${VERSION}"; then
-        check_fail "Version tag '${VERSION}' is already in use."
-    fi
-    run git tag -s -a "${VERSION}" \
-        -m "New release tag version: '${VERSION}'." \
-        -m "$(awk '/^#/{if(NR>1)exit}/^[^#]/{print}' <CHANGELOG.md)"
-    run git push origin --tags
-}
-
-# Opens a PR that bumps ${VERSION} to ${NEXT_VERSION}.
-function do_bump() {
-    echo "Next version: ${NEXT_VERSION}"
-
-    bump_module_version
-    prepend_changelog
-
-    local next_branch="chore/bump_version_to_${NEXT_VERSION}"
-
-    run git checkout -b "${next_branch}"
-    run git add MODULE.bazel
-    run git add CHANGELOG.md
-    run git commit -m "Bump version to ${NEXT_VERSION}"
-    run git push -u origin "${next_branch}"
-    run git push
-
-    if ! which gh >/dev/null; then
-        echo "WARNING: 'gh' not found; created branch '${next_branch}' but no PR." 1>&2
-        return
-    fi
-
-    local bump_text="Bump version from ${VERSION} to ${NEXT_VERSION}"
-    local merge_title="${bump_text}"
-    local merge_subject="${bump_text}"
-    local merge_body="Auto approved version bump from ${VERSION} to ${NEXT_VERSION} by trigger script."
-
-    if [[ ${DRY_RUN} == 1 ]]; then
-        echo "DRY-RUN: create PR '${merge_title}', mark ready, approve, and admin-merge branch '${next_branch}'." 1>&2
-        return
-    fi
-
-    local prnum=""
-    local prurl=""
-    if gh pr create --title "${merge_title}" -b "Created by ${0}." 2>&1 | tee pr_create_output.txt; then
-        prnum="$(sed -rne 's,https?://github.com/[^/]+/[^/]+/pull/([0-9]+)$,\1,p' < pr_create_output.txt)"
-        prurl="$(sed -rne 's,https?://github.com/[^/]+/[^/]+/pull/([0-9]+)$,\0,p' < pr_create_output.txt)"
-    else
-        echo "ERROR: Cannot create PR:"
-        cat pr_create_output.txt
-    fi
-    if [[ "${prnum}" -gt 1 ]]; then
-        gh pr ready "${next_branch}"
-        gh pr review "${next_branch}" -a -b "${merge_body}" || true
-        if gh pr merge "${next_branch}" --admin -d -s -b "${merge_body}" -t "${merge_subject}"; then
-            git checkout main
-            git branch -d "${next_branch}"
-            echo "PR ${prnum} was merged via admin override. See: ${prurl}."
-        else
-            gh pr merge "${next_branch}" --auto -d -s -b "${merge_body}" -t "${merge_subject}"
-            git checkout main
-            git branch -d "${next_branch}" || true
-            echo "PR ${prnum} cannot be merged via admin override."
-            echo "Please approve it at ${prurl}."
-        fi
-    fi
-}
-
-validate
-
-case "${COMMAND}" in
-    tag)     do_tag ;;
-    bump)    do_bump ;;
-    release) do_tag; do_bump ;;
-esac
+git tag -s -a "${VERSION}" \
+    -m "New release tag version: '${VERSION}'." \
+    -m "$(awk '/^#/{if(NR>1)exit}/^[^#]/{print}' CHANGELOG.md)"
+git push origin "refs/tags/${VERSION}"
+echo "Pushed signed release tag '${VERSION}'. GitHub Actions will create the release and BCR PR."


### PR DESCRIPTION
Finalize the repository transfer and make 0.6.1 the first mboworks_bashtest release.\n\n- rename module, labels, runtime variable, docs, and BCR templates\n- document the transfer and PR #27 feature in the changelog\n- add CODEOWNERS for @helly25 and @Fab-Cat\n- enforce post-release version advancement using complete tag history\n- simplify releasing to a clean-main signed tag without automated PR approval\n- enable release attestation permissions and mark releases non-prerelease\n\nPublished helly25_bashtest versions remain untouched.\n\nValidation:\n- pre-commit run --all-files\n- bazel test //...