### PR TITLE
Finish bashtest transfer cleanup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,9 @@ jobs:
       id-token: write
     with:
       release_files: bashtest-*.tar.gz
-      prerelease: false
+      # Keep the GitHub release provisional until the secondary BCR
+      # publication process has completed.
+      prerelease: true
 
   # Mirror the release to the Bazel Central Registry (replaces the retired
   # publish-to-bcr GitHub App). See .github/workflows/publish.yaml.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
     name: No TODOs without context
     description: |
       * Use descriptive, referenceable TODOs. Examples:
-        * `// TODO(nero.windstriker@helly25.com)`
+        * `// TODO(marcus.boerger@gmail.com)`
         * `# FIXME(https://github.com/mboworks/bashtest/issues/42)`
       * From the google style guide:
         Use FIXME/TODO comments for code that is temporary, a short-term solution.

--- a/README.md
+++ b/README.md
@@ -93,5 +93,5 @@ This repository requires bash to work (Linux, MacOs).
 Check [Releases](https://github.com/mboworks/bashtest/releases) for details. All that is needed is a `bazel_dep` instruction with the correct version.
 
 ```
-bazel_dep(name = "mboworks_bashtest", version = "0.0.0")
+bazel_dep(name = "mboworks_bashtest", version = "0.6.1")
 ```


### PR DESCRIPTION
## Summary

- use the released `mboworks_bashtest@0.6.1` version in the installation example
- replace the stale `helly25.com` TODO identity example

## Validation

- `git diff --check`
- `pre-commit run --all-files`
- `bazel test //...`